### PR TITLE
Add predictive patient risk API and bulk reminders flow

### DIFF
--- a/app/api/reminders/schedule/bulk/route.ts
+++ b/app/api/reminders/schedule/bulk/route.ts
@@ -1,0 +1,82 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/reminders/schedule/bulk
+// Body: { org_id: string, items: Array<{ channel?: "whatsapp"|"sms", target: string, template?: string, message?: string }>, schedule_at?: string }
+// Valida E.164 y reusa /api/reminders/schedule reenviando cookies (Next 15).
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { normalizeE164, isE164 } from "@/lib/templates";
+import { cookies as nextCookies } from "next/headers";
+
+export async function POST(req: NextRequest) {
+  // MODE: session
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    items?: Array<{
+      channel?: "whatsapp" | "sms";
+      target: string;
+      template?: string;
+      message?: string;
+    }>;
+    schedule_at?: string;
+  };
+
+  if (!body?.org_id || !Array.isArray(body?.items)) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id e items son requeridos" } },
+      { status: 400 }
+    );
+  }
+  if (body.items.length === 0 || body.items.length > 100) {
+    return NextResponse.json(
+      { ok: false, error: { code: "LIMIT", message: "items debe ser 1..100" } },
+      { status: 400 }
+    );
+  }
+
+  // cookies (Next 15)
+  const cookieStore = await nextCookies();
+  const cookieHeader = cookieStore.getAll().map((c) => `${c.name}=${c.value}`).join("; ");
+
+  let okCount = 0;
+  const results: Array<{ target: string; ok: boolean; error?: string }> = [];
+  for (const it of body.items) {
+    const ch = it.channel ?? "whatsapp";
+    const phone = normalizeE164(it.target || "");
+    if (!isE164(phone)) {
+      results.push({ target: it.target, ok: false, error: "Teléfono inválido (E.164)" });
+      continue;
+    }
+    const r = await fetch(`${new URL(req.url).origin}/api/reminders/schedule`, {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie: cookieHeader },
+      body: JSON.stringify({
+        org_id: body.org_id,
+        item: {
+          channel: ch,
+          target: phone,
+          template: it.template || "recordatorio_riesgo",
+          schedule_at: body.schedule_at || new Date().toISOString(),
+          meta: { message: it.message || "Te esperamos en tu próxima cita." },
+        },
+      }),
+    }).catch(() => null);
+    const j = await r?.json().catch(() => null);
+    if (j?.ok) {
+      okCount += 1;
+      results.push({ target: phone, ok: true });
+    } else {
+      results.push({ target: phone, ok: false, error: j?.error?.message || "falló" });
+    }
+  }
+
+  return NextResponse.json({ ok: true, data: { sent: okCount, total: body.items.length, results } });
+}

--- a/app/api/reports/agenda/risk/patients/predict/json/route.ts
+++ b/app/api/reports/agenda/risk/patients/predict/json/route.ts
@@ -1,0 +1,84 @@
+// MODE: session (user-scoped, cookies)
+// GET /api/reports/agenda/risk/patients/predict/json?org_id&days?&tz?&min_n?&top?
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { type Booking } from "@/lib/reports/agenda";
+import { weeklyRatesByPatient, deltaRecent } from "@/lib/reports/predictions";
+import { cookies as nextCookies } from "next/headers";
+
+async function fetchAllWithCookies(origin: string, path: string, params: URLSearchParams) {
+  const out: any[] = [];
+  let page = 1, pageSize = 1000;
+  const cookieStore = await nextCookies();
+  const cookieHeader = cookieStore.getAll().map((c) => `${c.name}=${c.value}`).join("; ");
+  while (page <= 20) {
+    params.set("page", String(page)); params.set("pageSize", String(pageSize));
+    const r = await fetch(`${origin}${path}?${params.toString()}`, {
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+    const j = await r.json().catch(() => null);
+    const arr: any[] = Array.isArray(j) ? j : j?.data ?? [];
+    if (!arr?.length) break;
+    out.push(...arr);
+    if (arr.length < pageSize) break;
+    page += 1;
+  }
+  return out as Booking[];
+}
+
+export async function GET(req: NextRequest) {
+  // MODE: session
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) return NextResponse.json({ ok:false, error:{ code:"UNAUTHORIZED", message:"No autenticado" }}, { status:401 });
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  const tz = url.searchParams.get("tz") ?? "America/Mexico_City";
+  const days = Math.min(180, Math.max(30, parseInt(url.searchParams.get("days") ?? "90", 10)));
+  const min_n = Math.max(1, parseInt(url.searchParams.get("min_n") ?? "3", 10));
+  const top = Math.max(1, parseInt(url.searchParams.get("top") ?? "50", 10));
+  if (!org_id) return NextResponse.json({ ok:false, error:{ code:"BAD_REQUEST", message:"org_id requerido" }}, { status:400 });
+
+  const to = new Date();
+  const from = new Date(to); from.setDate(to.getDate() - (days - 1));
+  const params = new URLSearchParams({ org_id, from: from.toISOString().slice(0,10), to: to.toISOString().slice(0,10) });
+
+  const bookings = await fetchAllWithCookies(url.origin, "/api/cal/bookings", params);
+  const byPat = weeklyRatesByPatient(bookings);
+
+  type Row = { patient_key: string; patient_name: string; current_rate: number; trend_30d: number; predicted_score: number; predicted_band: "low"|"med"|"high" };
+  const nameMap = new Map<string, string>();
+  for (const b of bookings) {
+    const k = (b.patient_id || b.patient || "NA").toString();
+    if (!nameMap.has(k)) nameMap.set(k, (b.patient_name || b.patient || k).toString());
+  }
+
+  const out: Row[] = [];
+  for (const [pid, series] of byPat) {
+    // rate actual = promedio últimas 4 semanas (robusto al ruido)
+    const n = series.length;
+    const recent = series.slice(Math.max(0, n - 4));
+    const avgRecent = recent.length ? recent.reduce((s, x) => s + x.rate, 0) / recent.length : 0;
+    const d30 = deltaRecent(series, 4); // aprox 4 semanas
+    const predicted = Math.max(0, Math.min(1, avgRecent + 0.5 * d30));
+    const band: Row["predicted_band"] = predicted >= 0.5 ? "high" : predicted >= 0.25 ? "med" : "low";
+
+    // aplicar min_n usando el recuento total en la ventana
+    const total = bookings.filter(b => (b.patient_id || b.patient || "NA").toString() === pid).length;
+    if (total < min_n) continue;
+
+    out.push({
+      patient_key: pid,
+      patient_name: nameMap.get(pid) || pid,
+      current_rate: Math.round(avgRecent * 1000) / 1000,
+      trend_30d: Math.round(d30 * 1000) / 1000,
+      predicted_score: Math.round(predicted * 1000) / 1000,
+      predicted_band: band,
+    });
+  }
+
+  const sorted = out.sort((a,b)=> b.predicted_score - a.predicted_score);
+  return NextResponse.json({ ok:true, data: sorted.slice(0, top), meta: { org_id, days, tz, min_n, top } });
+}

--- a/components/reports/agendapatientrisk.tsx
+++ b/components/reports/agendapatientrisk.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { isE164, normalizeE164 } from "@/lib/templates";
+import { buildCalLink } from "@/lib/integrations/cal";
 
 type Row = {
   patient_key: string;
@@ -14,14 +15,34 @@ type Row = {
   ns_streak: number;
   days_since_attended: number | null;
   risk_score: number;
-  risk_band: "low"|"med"|"high";
+  risk_band: "low" | "med" | "high";
 };
 
-function iso(d: Date) { return d.toISOString().slice(0,10); }
+type Pred = {
+  patient_key: string;
+  patient_name: string;
+  current_rate: number;
+  trend_30d: number;
+  predicted_score: number;
+  predicted_band: "low" | "med" | "high";
+};
+
+function iso(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+function cls(...xs: Array<string | false | null | undefined>) {
+  return xs.filter(Boolean).join(" ");
+}
 
 export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
-  const today = useMemo(()=> new Date(), []);
-  const first = useMemo(()=> { const d=new Date(today); d.setMonth(d.getMonth()-1); d.setDate(1); return d; }, [today]);
+  const today = useMemo(() => new Date(), []);
+  const first = useMemo(() => {
+    const d = new Date(today);
+    d.setMonth(d.getMonth() - 1);
+    d.setDate(1);
+    return d;
+  }, [today]);
+
   const [from, setFrom] = useState(iso(first));
   const [to, setTo] = useState(iso(today));
   const [tz, setTz] = useState("America/Mexico_City");
@@ -30,17 +51,29 @@ export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(false);
 
+  // selección
+  const [sel, setSel] = useState<Record<string, boolean>>({});
+  const selectedKeys = Object.keys(sel).filter((k) => sel[k]);
+
+  // predicción
+  const [showPred, setShowPred] = useState(false);
+  const [predLoading, setPredLoading] = useState(false);
+  const [preds, setPreds] = useState<Record<string, Pred>>({});
+
   // vistas guardadas
   const scope = "risk_patients";
-  const [views, setViews] = useState<{ id:string; name:string; filters:any }[]>([]);
+  const [views, setViews] = useState<{ id: string; name: string; filters: any }[]>([]);
   const [viewName, setViewName] = useState("");
 
   async function load() {
     setLoading(true);
-    const p = new URLSearchParams({ org_id: orgId, from, to, tz, min_n:String(minN), top:String(top) });
+    const p = new URLSearchParams({ org_id: orgId, from, to, tz, min_n: String(minN), top: String(top) });
     const r = await fetch(`/api/reports/agenda/risk/patients/json?${p.toString()}`);
     const j = await r.json();
-    setRows(j?.ok ? j.data : []);
+    const arr: Row[] = j?.ok ? j.data : [];
+    setRows(arr);
+    // limpia selección
+    setSel({});
     setLoading(false);
   }
 
@@ -51,7 +84,11 @@ export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
     setViews(j?.ok ? j.data : []);
   }
 
-  useEffect(()=>{ load(); loadViews(); }, [orgId]);
+  useEffect(() => {
+    load();
+    loadViews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId]);
 
   function applyView(v: any) {
     const f = v.filters || {};
@@ -63,16 +100,23 @@ export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
   }
 
   async function saveView() {
-    if (!viewName.trim()) { alert("Ponle un nombre a la vista"); return; }
+    if (!viewName.trim()) {
+      alert("Ponle un nombre a la vista");
+      return;
+    }
     const body = { org_id: orgId, scope, name: viewName.trim(), filters: { from, to, tz, min_n: minN, top } };
-    const r = await fetch("/api/saved-views/upsert", { method:"POST", headers:{ "content-type":"application/json" }, body: JSON.stringify(body) });
+    const r = await fetch("/api/saved-views/upsert", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     const j = await r.json();
-    if (!j.ok) alert(j.error?.message ?? "No se pudo guardar"); else loadViews();
+    if (!j.ok) alert(j.error?.message ?? "No se pudo guardar");
+    else loadViews();
   }
 
   async function sendReminder(phone: string, name: string) {
     const norm = normalizeE164(phone);
-    if (!isE164(norm)) { alert("Teléfono inválido (usa formato E.164: +52...)"); return; }
+    if (!isE164(norm)) {
+      alert("Teléfono inválido (usa formato E.164: +52...)");
+      return;
+    }
     const body = {
       org_id: orgId,
       item: {
@@ -80,52 +124,139 @@ export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
         target: norm,
         template: "recordatorio_riesgo",
         schedule_at: new Date().toISOString(),
-        meta: { message: `Hola ${name}, te esperamos en tu próxima cita. Si necesitas reagendar, contesta este mensaje.` }
-      }
+        meta: { message: `Hola ${name}, te esperamos en tu próxima cita. Si necesitas reagendar, contesta este mensaje.` },
+      },
     };
-    const r = await fetch("/api/reminders/schedule", { method:"POST", headers:{ "content-type":"application/json" }, body: JSON.stringify(body) });
+    const r = await fetch("/api/reminders/schedule", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     const j = await r.json();
     if (!j.ok) alert(j.error?.message ?? "No se pudo enviar");
   }
 
+  async function sendBulk() {
+    if (selectedKeys.length === 0) return;
+    const items: Array<{ target: string }> = [];
+    for (const key of selectedKeys) {
+      const el = document.getElementById(`tel-${key}`) as HTMLInputElement | null;
+      const phone = el?.value ?? "";
+      const norm = normalizeE164(phone);
+      if (isE164(norm)) items.push({ target: norm });
+    }
+    if (items.length === 0) {
+      alert("Ninguno de los seleccionados tiene teléfono válido (+E.164).");
+      return;
+    }
+    const r = await fetch("/api/reminders/schedule/bulk", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, items }),
+    });
+    const j = await r.json();
+    if (!j.ok) alert(j.error?.message ?? "Fallo el envío masivo");
+    else alert(`Enviados ${j.data.sent}/${j.data.total}`);
+  }
+
+  async function togglePred() {
+    const next = !showPred;
+    setShowPred(next);
+    if (next) {
+      setPredLoading(true);
+      const p = new URLSearchParams({ org_id: orgId, days: "90", tz, min_n: String(minN), top: String(top) });
+      const r = await fetch(`/api/reports/agenda/risk/patients/predict/json?${p.toString()}`);
+      const j = await r.json();
+      const map: Record<string, Pred> = {};
+      if (j?.ok) for (const x of j.data as Pred[]) map[x.patient_key] = x;
+      setPreds(map);
+      setPredLoading(false);
+    }
+  }
+
   const base = typeof window !== "undefined" ? window.location.origin : "";
 
+  // UI
   return (
     <section className="rounded-2xl border p-4 space-y-4">
       {/* Filtros */}
       <div className="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
-        <div><label className="block text-sm mb-1">Desde</label><input type="date" className="rounded border px-3 py-2 w-full" value={from} onChange={e=>setFrom(e.target.value)} /></div>
-        <div><label className="block text-sm mb-1">Hasta</label><input type="date" className="rounded border px-3 py-2 w-full" value={to} onChange={e=>setTo(e.target.value)} /></div>
-        <div><label className="block text-sm mb-1">TZ</label><input className="rounded border px-3 py-2 w-full" value={tz} onChange={e=>setTz(e.target.value)} /></div>
-        <div><label className="block text-sm mb-1">Mín citas</label><input type="number" min={1} className="rounded border px-3 py-2 w-full" value={minN} onChange={e=>setMinN(Math.max(1, parseInt(e.target.value||"1",10)))} /></div>
-        <div><label className="block text-sm mb-1">Top N</label><input type="number" min={1} className="rounded border px-3 py-2 w-full" value={top} onChange={e=>setTop(Math.max(1, parseInt(e.target.value||"1",10)))} /></div>
+        <div>
+          <label className="block text-sm mb-1">Desde</label>
+          <input type="date" className="rounded border px-3 py-2 w-full" value={from} onChange={(e) => setFrom(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Hasta</label>
+          <input type="date" className="rounded border px-3 py-2 w-full" value={to} onChange={(e) => setTo(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">TZ</label>
+          <input className="rounded border px-3 py-2 w-full" value={tz} onChange={(e) => setTz(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Mín citas</label>
+          <input type="number" min={1} className="rounded border px-3 py-2 w-full" value={minN} onChange={(e) => setMinN(Math.max(1, parseInt(e.target.value || "1", 10)))} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Top N</label>
+          <input type="number" min={1} className="rounded border px-3 py-2 w-full" value={top} onChange={(e) => setTop(Math.max(1, parseInt(e.target.value || "1", 10)))} />
+        </div>
         <div className="flex gap-2">
-          <button className="rounded px-4 py-2 border w-full" onClick={load}>Aplicar</button>
+          <button className="rounded px-4 py-2 border w-full" onClick={load}>
+            Aplicar
+          </button>
           <a
             href={`${base}/api/export/agenda/risk/patients/xlsx?org_id=${orgId}&from=${from}&to=${to}&tz=${encodeURIComponent(tz)}&min_n=${minN}&top=${top}`}
             className="rounded px-4 py-2 border w-full text-center"
-          >XLSX</a>
+          >
+            XLSX
+          </a>
         </div>
         <div className="flex gap-2">
-          <select className="rounded border px-3 py-2 w-full" onChange={e=>{
-            const v = views.find(x=>x.id===e.target.value);
-            if (v) applyView(v);
-          }}>
+          <select
+            className="rounded border px-3 py-2 w-full"
+            onChange={(e) => {
+              const v = views.find((x) => x.id === e.target.value);
+              if (v) applyView(v);
+            }}
+          >
             <option value="">Vistas guardadas…</option>
-            {views.map(v=> <option key={v.id} value={v.id}>{v.name}</option>)}
+            {views.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
           </select>
         </div>
       </div>
 
-      {/* Guardar vista */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+      {/* Guardar vista & predicción */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
         <div className="md:col-span-3">
           <label className="block text-sm mb-1">Nombre de la vista</label>
-          <input className="rounded border px-3 py-2 w-full" value={viewName} onChange={e=>setViewName(e.target.value)} placeholder="Ej. Últimos 90 días, Top 100" />
+          <input className="rounded border px-3 py-2 w-full" value={viewName} onChange={(e) => setViewName(e.target.value)} placeholder="Ej. Últimos 90 días, Top 100" />
         </div>
         <div>
-          <button className="rounded px-4 py-2 border w-full" onClick={saveView}>Guardar vista</button>
+          <button className="rounded px-4 py-2 border w-full" onClick={saveView}>
+            Guardar vista
+          </button>
         </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm">
+            <input type="checkbox" className="mr-2" checked={showPred} onChange={togglePred} /> Mostrar predicción
+          </label>
+          {predLoading && <span className="text-xs text-slate-500">Calculando…</span>}
+        </div>
+      </div>
+
+      {/* Barra de acciones masivas */}
+      <div
+        className={cls(
+          "flex items-center gap-3 border rounded-xl px-3 py-2",
+          selectedKeys.length ? "opacity-100" : "opacity-50 pointer-events-none"
+        )}
+        aria-live="polite"
+      >
+        <span className="text-sm">Seleccionados: {selectedKeys.length}</span>
+        <button className="rounded px-3 py-1 border" onClick={sendBulk}>
+          Enviar recordatorio (WA)
+        </button>
       </div>
 
       {/* Tabla */}
@@ -133,66 +264,154 @@ export default function AgendaPatientRisk({ orgId }: { orgId: string }) {
         <table className="w-full text-sm">
           <thead className="bg-gray-50">
             <tr>
-              <Th>Riesgo</Th><Th>Paciente</Th><Th>Citas</Th><Th>No-show</Th><Th>Tasa</Th><Th>Racha NS</Th><Th>Días desde atendida</Th><Th>Acciones</Th>
+              <Th>
+                <input
+                  aria-label="Seleccionar todos"
+                  type="checkbox"
+                  checked={rows.length > 0 && selectedKeys.length === rows.length}
+                  onChange={(e) => {
+                    const v = e.target.checked;
+                    const n: Record<string, boolean> = {};
+                    if (v) for (const r of rows) n[r.patient_key] = true;
+                    setSel(n);
+                  }}
+                />
+              </Th>
+              <Th>Riesgo</Th>
+              <Th>Paciente</Th>
+              <Th>Citas</Th>
+              <Th>No-show</Th>
+              <Th>Tasa</Th>
+              <Th>Racha NS</Th>
+              <Th>Días desde atendida</Th>
+              {showPred && <Th>Tendencia 30d</Th>}
+              {showPred && <Th>Predicho</Th>}
+              <Th>Acciones</Th>
             </tr>
           </thead>
           <tbody>
-            {loading && <tr><td colSpan={8} className="px-3 py-6 text-center">Procesando…</td></tr>}
-            {!loading && rows.length === 0 && <tr><td colSpan={8} className="px-3 py-6 text-center">Sin resultados para el rango seleccionado.</td></tr>}
-            {rows.map(r => (
-              <tr key={r.patient_key} className="border-t hover:bg-gray-50">
-                <td className="px-3 py-2">
-                  <span
-                    className={
-                      "inline-flex items-center gap-2 px-2 py-1 rounded-full text-xs " +
-                      (r.risk_band === "high" ? "bg-rose-100 text-rose-800" :
-                       r.risk_band === "med" ? "bg-amber-100 text-amber-800" :
-                       "bg-emerald-100 text-emerald-800")
-                    }
-                    aria-label={`Riesgo ${r.risk_band}`}
-                  >
-                    ● {Math.round(r.risk_score*100)}%
-                  </span>
-                </td>
-                <td className="px-3 py-2">{r.patient_name}</td>
-                <Td>{r.total}</Td>
-                <Td>{r.no_show}</Td>
-                <Td>{Math.round(r.ns_rate*100)}%</Td>
-                <Td>{r.ns_streak}</Td>
-                <Td>{r.days_since_attended ?? "—"}</Td>
-                <td className="px-3 py-2">
-                  <div className="flex flex-wrap gap-2 items-center">
-                    <input
-                      aria-label="Teléfono para recordatorio"
-                      placeholder="+52..."
-                      className="rounded border px-2 py-1 w-36"
-                      id={`tel-${r.patient_key}`}
-                      onKeyDown={(e)=>{
-                        if (e.key === "Enter") {
-                          const val = (e.target as HTMLInputElement).value;
-                          sendReminder(val, r.patient_name);
-                        }
-                      }}
-                    />
-                    <button className="rounded px-3 py-1 border" onClick={()=>{
-                      const val = (document.getElementById(`tel-${r.patient_key}`) as HTMLInputElement)?.value || "";
-                      sendReminder(val, r.patient_name);
-                    }}>Recordar WA</button>
-                    <a className="rounded px-3 py-1 border" href={`/pacientes?q=${encodeURIComponent(r.patient_name)}`}>Ver paciente</a>
-                    <a className="rounded px-3 py-1 border" href={`/agenda`}>Reagendar</a>
-                  </div>
+            {loading && (
+              <tr>
+                <td colSpan={11} className="px-3 py-6 text-center">
+                  Procesando…
                 </td>
               </tr>
-            ))}
+            )}
+            {!loading && rows.length === 0 && (
+              <tr>
+                <td colSpan={11} className="px-3 py-6 text-center">
+                  Sin resultados para el rango seleccionado.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => {
+              const p = preds[r.patient_key];
+              const cal = buildCalLink({ name: r.patient_name, notes: "Reagendado desde Sanoa" });
+              return (
+                <tr key={r.patient_key} className="border-t hover:bg-gray-50">
+                  <Td>
+                    <input
+                      aria-label={`Seleccionar ${r.patient_name}`}
+                      type="checkbox"
+                      checked={!!sel[r.patient_key]}
+                      onChange={(e) => setSel((s) => ({ ...s, [r.patient_key]: e.target.checked }))}
+                    />
+                  </Td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={cls(
+                        "inline-flex items-center gap-2 px-2 py-1 rounded-full text-xs",
+                        r.risk_band === "high" ? "bg-rose-100 text-rose-800" : r.risk_band === "med" ? "bg-amber-100 text-amber-800" : "bg-emerald-100 text-emerald-800"
+                      )}
+                      aria-label={`Riesgo ${r.risk_band}`}
+                    >
+                      ● {Math.round(r.risk_score * 100)}%
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">{r.patient_name}</td>
+                  <Td>{r.total}</Td>
+                  <Td>{r.no_show}</Td>
+                  <Td>{Math.round(r.ns_rate * 100)}%</Td>
+                  <Td>{r.ns_streak}</Td>
+                  <Td>{r.days_since_attended ?? "—"}</Td>
+                  {showPred && (
+                    <Td>
+                      {p ? (
+                        <span className={cls(p.trend_30d > 0 ? "text-rose-700" : p.trend_30d < 0 ? "text-emerald-700" : "text-slate-700")}>
+                          {Math.round((p.trend_30d || 0) * 100)}%
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </Td>
+                  )}
+                  {showPred && (
+                    <Td>
+                      {p ? (
+                        <span
+                          className={cls(
+                            "inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs",
+                            p.predicted_band === "high"
+                              ? "bg-rose-100 text-rose-800"
+                              : p.predicted_band === "med"
+                              ? "bg-amber-100 text-amber-800"
+                              : "bg-emerald-100 text-emerald-800"
+                          )}
+                        >
+                          ● {Math.round(p.predicted_score * 100)}%
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </Td>
+                  )}
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap gap-2 items-center">
+                      <input
+                        aria-label="Teléfono para recordatorio"
+                        placeholder="+52..."
+                        className="rounded border px-2 py-1 w-36"
+                        id={`tel-${r.patient_key}`}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            const val = (e.target as HTMLInputElement).value;
+                            sendReminder(val, r.patient_name);
+                          }
+                        }}
+                      />
+                      <button
+                        className="rounded px-3 py-1 border"
+                        onClick={() => {
+                          const val = (document.getElementById(`tel-${r.patient_key}`) as HTMLInputElement)?.value || "";
+                          sendReminder(val, r.patient_name);
+                        }}
+                      >
+                        Recordar WA
+                      </button>
+                      <a className="rounded px-3 py-1 border" href={cal} target="_blank" rel="noreferrer">
+                        Reagendar (Cal.com)
+                      </a>
+                      <a className="rounded px-3 py-1 border" href={`/pacientes?q=${encodeURIComponent(r.patient_name)}`}>
+                        Ver paciente
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
       <p className="text-xs text-slate-500">
-        Nota: el score es heurístico (proporción de no-shows, racha y recencia). Úsalo como apoyo para prevención, no como diagnóstico.
+        Nota: el score y la predicción son heurísticos (tasa, racha y tendencia). Úsalos como apoyo para prevención, no como diagnóstico.
       </p>
     </section>
   );
 }
 
-function Th({ children }: { children: React.ReactNode }) { return <th className="text-left px-3 py-2">{children}</th>; }
-function Td({ children }: { children: React.ReactNode }) { return <td className="px-3 py-2">{children}</td>; }
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="text-left px-3 py-2">{children}</th>;
+}
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-3 py-2">{children}</td>;
+}

--- a/lib/integrations/cal.ts
+++ b/lib/integrations/cal.ts
@@ -1,0 +1,24 @@
+export type BuildCalLinkOptions = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  notes?: string;
+};
+
+const DEFAULT_URL = process.env.NEXT_PUBLIC_CAL_SCHEDULING_URL || "/agenda";
+
+/**
+ * Construye un link a Cal.com (o fallback) con prefill básico.
+ * Acepta URLs absolutas o relativas; agrega query params tipo prefill[name].
+ */
+export function buildCalLink(opts: BuildCalLinkOptions = {}) {
+  const base = DEFAULT_URL;
+  const usp = new URLSearchParams();
+  if (opts.name) usp.set("prefill[name]", opts.name);
+  if (opts.email) usp.set("prefill[email]", opts.email);
+  if (opts.phone) usp.set("prefill[phone]", opts.phone);
+  if (opts.notes) usp.set("prefill[notes]", opts.notes);
+  const qs = usp.toString();
+  if (!qs) return base;
+  return `${base}${base.includes("?") ? "&" : "?"}${qs}`;
+}

--- a/lib/reports/predictions.ts
+++ b/lib/reports/predictions.ts
@@ -1,0 +1,63 @@
+// lib/reports/predictions.ts
+import { type Booking } from "./agenda";
+
+/** Normaliza a clave "YYYY-WW" (semana ISO simple) en tz aproximado (ignora DST). */
+export function weekKey(d: Date) {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  // Jueves como pivote ISO
+  const dayNum = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - dayNum + 3);
+  const isoYear = date.getUTCFullYear();
+  const jan4 = new Date(Date.UTC(isoYear, 0, 4));
+  const week = Math.round(
+    (date.getTime() - jan4.getTime()) / 86400000 / 7 + 1
+  );
+  return `${isoYear}-${String(week).padStart(2, "0")}`;
+}
+
+function isNoShow(status?: string | null) {
+  const s = (status ?? "").toLowerCase();
+  return /no[\s_-]?show|missed|did[_\s-]?not[_\s-]?attend/.test(s);
+}
+
+/** Agrega por semana el rate de no-show del paciente. */
+export function weeklyRatesByPatient(bookings: Booking[]) {
+  const map = new Map<string, Map<string, { t: number; ns: number }>>();
+  for (const b of bookings) {
+    const pid = (b.patient_id || b.patient || "NA").toString();
+    const start = b.start_at ? new Date(b.start_at) : null;
+    if (!start) continue;
+    const wk = weekKey(start);
+    const m = map.get(pid) ?? new Map();
+    const cell = m.get(wk) ?? { t: 0, ns: 0 };
+    cell.t += 1;
+    if (isNoShow(b.status ?? "")) cell.ns += 1;
+    m.set(wk, cell);
+    map.set(pid, m);
+  }
+  // a arrays ordenados por semana
+  const out = new Map<string, Array<{ week: string; rate: number }>>();
+  for (const [pid, m] of map) {
+    const arr = Array.from(m.entries())
+      .map(([week, v]) => ({ week, rate: v.t ? v.ns / v.t : 0 }))
+      .sort((a, b) => (a.week < b.week ? -1 : a.week > b.week ? 1 : 0));
+    out.set(pid, arr);
+  }
+  return out;
+}
+
+/** Diferencia entre promedio reciente (N semanas) y previo (N semanas) */
+export function deltaRecent(
+  series: Array<{ rate: number }>,
+  recentWeeks = 4
+) {
+  if (!series.length) return 0;
+  const n = series.length;
+  const lo = Math.max(0, n - recentWeeks * 2);
+  const mid = Math.max(0, n - recentWeeks);
+  const prev = series.slice(lo, mid);
+  const curr = series.slice(mid, n);
+  const avg = (xs: typeof series) =>
+    xs.length ? xs.reduce((s, x) => s + x.rate, 0) / xs.length : 0;
+  return avg(curr) - avg(prev);
+}


### PR DESCRIPTION
## Summary
- add utilities to compute weekly patient no-show rates and expose a predictive risk API
- introduce a bulk reminder scheduling endpoint that validates numbers and reuses the existing scheduler
- enhance the agenda patient risk UI with prediction toggles, bulk reminder actions, and Cal.com links

## Testing
- pnpm lint *(fails: missing dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad573efc0832ab146e1028822b2de