### PR TITLE
Add patient tasks management APIs and UI

### DIFF
--- a/app/(app)/print/prescriptions/[id]/page.tsx
+++ b/app/(app)/print/prescriptions/[id]/page.tsx
@@ -1,0 +1,100 @@
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { getUserLetterheadURL, renderLetterheadHTML } from "@/lib/branding/letterhead";
+
+type PrescriptionJson = {
+  id: string;
+  org_id: string;
+  patient?: { name?: string; age?: string; id?: string } | null;
+  doctor?: { id: string; name: string; specialty?: string | null } | null;
+  issued_at?: string | null;
+  items?: Array<{ name: string; dose?: string; freq?: string; notes?: string }> | null;
+  notes?: string | null;
+};
+
+export default async function PrintPrescriptionPage({ params }: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return <div className="p-6 text-rose-700">Necesitas iniciar sesión.</div>;
+  }
+
+  // Carga JSON de la receta usando el endpoint existente (reusa cookies de SSR)
+  const origin = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const r = await fetch(`${origin}/api/prescriptions/${params.id}/json`, { cache: "no-store" });
+  const j = (await r.json().catch(() => null)) as { ok?: boolean; data?: PrescriptionJson } | null;
+  if (!j?.ok || !j.data) {
+    return <div className="p-6 text-rose-700">No se pudo cargar la receta.</div>;
+  }
+  const p = j.data;
+  const specialistId = p.doctor?.id || u.user.id;
+
+  // Membrete del especialista
+  const letterheadUrl = await getUserLetterheadURL(supa as any, specialistId);
+  const headerHtml = renderLetterheadHTML({
+    specialistName: p.doctor?.name || "Especialista",
+    specialty: p.doctor?.specialty || null,
+    orgName: "", // si tienes orgName en el JSON, úsalo aquí
+    letterheadUrl,
+  });
+
+  // Render minimalista imprimible
+  return (
+    <html>
+      <head>
+        <title>Receta #{p.id}</title>
+        <meta name="robots" content="noindex" />
+        <style>{`
+          @media print { @page { margin: 20mm; } .no-print { display: none; } }
+          body { font-family: ui-sans-serif, system-ui; color: #0f172a; }
+          .card { max-width: 720px; margin: 24px auto; background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 24px; }
+          h1 { font-size: 18px; font-weight: 700; margin: 0 0 8px; }
+          h2 { font-size: 14px; font-weight: 600; margin: 16px 0 8px; }
+          .muted { color: #475569; }
+          .item { border: 1px solid #e2e8f0; border-radius: 12px; padding: 12px; margin-top: 8px; }
+        `}</style>
+      </head>
+      <body>
+        <div className="card">
+          {/* header injectado */}
+          <div dangerouslySetInnerHTML={{ __html: headerHtml }} />
+          <h1>Receta médica</h1>
+          <div className="muted">Folio: {p.id} — Emitida: {p.issued_at || "—"}</div>
+
+          <h2>Paciente</h2>
+          <div>
+            {p.patient?.name || "—"}{" "}
+            {p.patient?.age ? <span className="muted">({p.patient.age})</span> : null}
+          </div>
+
+          <h2>Indicaciones</h2>
+          {p.items?.length ? (
+            p.items.map((it, i) => (
+              <div className="item" key={i}>
+                <div>
+                  <strong>{it.name}</strong>
+                </div>
+                <div className="muted">{[it.dose, it.freq].filter(Boolean).join(" · ")}</div>
+                {it.notes ? <div>{it.notes}</div> : null}
+              </div>
+            ))
+          ) : (
+            <div className="muted">Sin ítems</div>
+          )}
+
+          {p.notes ? (
+            <>
+              <h2>Notas</h2>
+              <div>{p.notes}</div>
+            </>
+          ) : null}
+
+          <div className="no-print" style={{ marginTop: 16 }}>
+            <button onClick={() => window.print()} className="border rounded-lg px-3 py-2">
+              Imprimir
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/api/patients/autocomplete/route.ts
+++ b/app/api/patients/autocomplete/route.ts
@@ -1,0 +1,54 @@
+// MODE: session (user-scoped, cookies)
+// GET /api/patients/autocomplete?org_id=<uuid>&q=<text>&scope=mine|org
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  const q = (url.searchParams.get("q") || "").trim();
+  const scope = (url.searchParams.get("scope") || "mine").toLowerCase();
+  if (!org_id || !q) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id y q requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  // Intentar RPC (recomendado por rendimiento y precisión de "mis pacientes")
+  const { data: rpc, error: erpc } = await supa.rpc("patients_autocomplete", {
+    org: org_id,
+    q,
+    uid: u.user.id,
+    show_org: scope === "org",
+  });
+  if (!erpc && rpc) {
+    return NextResponse.json({ ok: true, data: rpc });
+  }
+
+  // Fallback simple si RPC aún no está disponible: buscar en tabla patients (existe en la mayoría de proyectos)
+  // Nota: esto no impone "sólo mis pacientes" sin el esquema; el RPC es lo correcto a activar.
+  const { data, error } = await supa
+    .from("patients")
+    .select("id, full_name")
+    .eq("org_id", org_id)
+    .ilike("full_name", `%${q}%`)
+    .limit(20);
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data: (data || []).map((x) => ({ id: x.id, label: x.full_name })) });
+}

--- a/app/api/tasks/assign/route.ts
+++ b/app/api/tasks/assign/route.ts
@@ -1,0 +1,76 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/tasks/assign
+// { org_id, module, patient_id, template_id?, title?, content?, due_date? }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    module?: string;
+    patient_id?: string;
+    template_id?: string;
+    title?: string;
+    content?: any;
+    due_date?: string | null;
+  };
+  if (!body?.org_id || !body?.module || !body?.patient_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id, module y patient_id son requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  let title = (body.title || "").toString().slice(0, 160);
+  let content = body.content ?? {};
+
+  if (body.template_id) {
+    const { data: tpl, error: eTpl } = await supa
+      .from("patient_task_templates")
+      .select("title,content")
+      .eq("id", body.template_id)
+      .eq("org_id", body.org_id)
+      .single();
+    if (eTpl) {
+      return NextResponse.json(
+        { ok: false, error: { code: "NOT_FOUND", message: "Plantilla no encontrada" } },
+        { status: 404 }
+      );
+    }
+    title = title || tpl.title;
+    content = Object.keys(content || {}).length ? content : tpl.content ?? {};
+  }
+
+  const { data, error } = await supa
+    .from("patient_tasks")
+    .insert({
+      org_id: body.org_id,
+      module: body.module,
+      patient_id: body.patient_id,
+      template_id: body.template_id ?? null,
+      title: title || "Tarea",
+      content,
+      status: "assigned",
+      due_date: body.due_date ?? null,
+      assigned_by: u.user.id,
+    })
+    .select("id,org_id,module,patient_id,title,status,due_date,assigned_by,created_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/tasks/complete/route.ts
+++ b/app/api/tasks/complete/route.ts
@@ -1,0 +1,52 @@
+// MODE: session (user-scoped, cookies)
+// PATCH /api/tasks/complete  { org_id, id, status? ('done'|'in_progress'|'assigned'), due_date? }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function PATCH(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    id?: string;
+    status?: string;
+    due_date?: string | null;
+  };
+  if (!body?.org_id || !body?.id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id e id requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  const patch: Record<string, unknown> = {};
+  if (body.status && ["done", "in_progress", "assigned"].includes(body.status)) {
+    patch.status = body.status;
+  }
+  if (typeof body.due_date !== "undefined") {
+    patch.due_date = body.due_date;
+  }
+
+  const { data, error } = await supa
+    .from("patient_tasks")
+    .update(patch)
+    .eq("id", body.id)
+    .eq("org_id", body.org_id)
+    .select("id,status,due_date,updated_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/tasks/list/route.ts
+++ b/app/api/tasks/list/route.ts
@@ -1,0 +1,47 @@
+// MODE: session (user-scoped, cookies)
+// GET /api/tasks/list?org_id&module?&patient_id?&status?
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  if (!org_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id requerido" } },
+      { status: 400 }
+    );
+  }
+
+  let q = supa
+    .from("patient_tasks")
+    .select("id,org_id,module,patient_id,template_id,title,content,status,due_date,assigned_by,created_at,updated_at")
+    .eq("org_id", org_id)
+    .order("created_at", { ascending: false });
+
+  const moduleName = url.searchParams.get("module");
+  const patient_id = url.searchParams.get("patient_id");
+  const status = url.searchParams.get("status");
+
+  if (moduleName) q = q.eq("module", moduleName);
+  if (patient_id) q = q.eq("patient_id", patient_id);
+  if (status) q = q.eq("status", status);
+
+  const { data, error } = await q;
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/tasks/templates/route.ts
+++ b/app/api/tasks/templates/route.ts
@@ -1,0 +1,120 @@
+// MODE: session (user-scoped, cookies)
+// GET: /api/tasks/templates?org_id&module
+// POST: /api/tasks/templates  { org_id, module, title, content }
+// DELETE: /api/tasks/templates  { id, org_id }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  const mod = url.searchParams.get("module");
+  if (!org_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id requerido" } },
+      { status: 400 }
+    );
+  }
+
+  let q = supa
+    .from("patient_task_templates")
+    .select("id,org_id,module,title,content,created_at,created_by")
+    .eq("org_id", org_id)
+    .order("created_at", { ascending: false });
+  if (mod) q = q.eq("module", mod);
+
+  const { data, error } = await q;
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    module?: string;
+    title?: string;
+    content?: any;
+  };
+  if (!body?.org_id || !body?.module || !body?.title) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id, module y title son requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supa
+    .from("patient_task_templates")
+    .insert({
+      org_id: body.org_id,
+      module: body.module,
+      title: String(body.title).slice(0, 160),
+      content: body.content ?? {},
+      created_by: u.user.id,
+    })
+    .select("id,org_id,module,title,content,created_at,created_by")
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}
+
+export async function DELETE(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as { id?: string; org_id?: string };
+  if (!body?.id || !body?.org_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "id y org_id requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await supa
+    .from("patient_task_templates")
+    .delete()
+    .eq("id", body.id)
+    .eq("org_id", body.org_id);
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/patients/PatientAutocomplete.tsx
+++ b/components/patients/PatientAutocomplete.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export default function PatientAutocomplete({
+  orgId,
+  scope = "mine",
+  onSelect,
+  placeholder = "Buscar paciente…",
+}: {
+  orgId: string;
+  scope?: "mine" | "org";
+  onSelect: (item: { id: string; label: string }) => void;
+  placeholder?: string;
+}) {
+  const [q, setQ] = useState("");
+  const [items, setItems] = useState<{ id: string; label: string }[]>([]);
+  const [open, setOpen] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!q.trim()) {
+      setItems([]);
+      setOpen(false);
+      return;
+    }
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(async () => {
+      const p = new URLSearchParams({ org_id: orgId, q, scope });
+      const r = await fetch(`/api/patients/autocomplete?${p.toString()}`, { cache: "no-store" });
+      const j = await r.json();
+      setItems(j?.ok ? j.data : []);
+      setOpen(true);
+    }, 150);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [q, orgId, scope]);
+
+  return (
+    <div className="relative">
+      <input
+        aria-autocomplete="list"
+        aria-expanded={open}
+        className="border rounded px-3 py-2 w-full"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        onFocus={() => {
+          if (items.length) setOpen(true);
+        }}
+        onBlur={() => setTimeout(() => setOpen(false), 100)}
+        placeholder={placeholder}
+      />
+      {open && items.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-10 bg-white border rounded mt-1 max-h-64 overflow-auto w-full shadow"
+        >
+          {items.map((it) => (
+            <li
+              role="option"
+              key={it.id}
+              className="px-3 py-2 hover:bg-gray-50 cursor-pointer"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(it);
+                setQ(it.label);
+                setOpen(false);
+              }}
+            >
+              {it.label}
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && !items.length && (
+        <div className="absolute z-10 bg-white border rounded mt-1 w-full px-3 py-2 text-sm text-slate-500">
+          Sin resultados
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/tasks/PatientTasksPanel.tsx
+++ b/components/tasks/PatientTasksPanel.tsx
@@ -1,0 +1,218 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Task = {
+  id: string;
+  title: string;
+  status: "assigned" | "in_progress" | "done";
+  due_date: string | null;
+  created_at: string;
+};
+
+type Template = {
+  id: string;
+  title: string;
+};
+
+export default function PatientTasksPanel({
+  orgId,
+  moduleName,
+  patientId,
+}: {
+  orgId: string;
+  moduleName: string;
+  patientId: string;
+}) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState("");
+  const [customTitle, setCustomTitle] = useState("");
+  const [customContent, setCustomContent] = useState<any>({});
+  const [customContentInput, setCustomContentInput] = useState("");
+  const [due, setDue] = useState<string>("");
+
+  async function load() {
+    const p = new URLSearchParams({ org_id: orgId, module: moduleName });
+    const r1 = await fetch(`/api/tasks/templates?${p.toString()}`);
+    const j1 = await r1.json();
+    setTemplates(j1?.ok ? j1.data : []);
+    const p2 = new URLSearchParams({ org_id: orgId, module: moduleName, patient_id: patientId });
+    const r2 = await fetch(`/api/tasks/list?${p2.toString()}`);
+    const j2 = await r2.json();
+    setTasks(j2?.ok ? j2.data : []);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, moduleName, patientId]);
+
+  async function assignTemplate(template_id: string) {
+    const r = await fetch("/api/tasks/assign", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        org_id: orgId,
+        module: moduleName,
+        patient_id: patientId,
+        template_id,
+        due_date: due || null,
+      }),
+    });
+    const j = await r.json();
+    if (!j.ok) alert(j.error?.message ?? "Error");
+    else load();
+  }
+
+  async function assignCustom() {
+    const r = await fetch("/api/tasks/assign", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        org_id: orgId,
+        module: moduleName,
+        patient_id: patientId,
+        title: customTitle,
+        content: customContent,
+        due_date: due || null,
+      }),
+    });
+    const j = await r.json();
+    if (!j.ok) alert(j.error?.message ?? "Error");
+    else {
+      setCustomTitle("");
+      setCustomContent({});
+      setCustomContentInput("");
+      load();
+    }
+  }
+
+  async function setStatus(id: string, status: "done" | "in_progress" | "assigned") {
+    const r = await fetch("/api/tasks/complete", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, id, status }),
+    });
+    const j = await r.json();
+    if (!j.ok) alert(j.error?.message ?? "Error");
+    else load();
+  }
+
+  return (
+    <section className="border rounded-2xl p-4 space-y-4">
+      <h3 className="font-semibold">Tareas del paciente</h3>
+
+      <div className="grid md:grid-cols-4 gap-3">
+        <div className="md:col-span-2">
+          <label className="block text-sm">Asignar desde plantilla</label>
+          <div className="flex gap-2">
+            <select
+              id="tpl"
+              className="border rounded px-3 py-2 w-full"
+              value={selectedTemplate}
+              onChange={(e) => setSelectedTemplate(e.target.value)}
+            >
+              <option value="">Selecciona…</option>
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.title}
+                </option>
+              ))}
+            </select>
+            <input
+              type="date"
+              className="border rounded px-3 py-2"
+              value={due}
+              onChange={(e) => setDue(e.target.value)}
+            />
+            <button
+              className="border rounded px-3 py-2"
+              onClick={() => {
+                if (selectedTemplate) assignTemplate(selectedTemplate);
+              }}
+            >
+              Asignar
+            </button>
+          </div>
+        </div>
+        <div className="md:col-span-2">
+          <label className="block text-sm">Asignar personalizada</label>
+          <div className="grid md:grid-cols-2 gap-2">
+            <input
+              className="border rounded px-3 py-2"
+              placeholder="Título"
+              value={customTitle}
+              onChange={(e) => setCustomTitle(e.target.value)}
+            />
+            <input
+              className="border rounded px-3 py-2"
+              placeholder="Contenido (JSON)"
+              value={customContentInput}
+              onChange={(e) => {
+                const value = e.target.value;
+                setCustomContentInput(value);
+                try {
+                  setCustomContent(JSON.parse(value || "{}"));
+                } catch {
+                  /* ignore */
+                }
+              }}
+            />
+          </div>
+          <div className="mt-2 flex gap-2">
+            <input
+              type="date"
+              className="border rounded px-3 py-2"
+              value={due}
+              onChange={(e) => setDue(e.target.value)}
+            />
+            <button className="border rounded px-3 py-2" onClick={assignCustom}>
+              Asignar
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded border overflow-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-3 py-2">Título</th>
+              <th className="text-left px-3 py-2">Estado</th>
+              <th className="text-left px-3 py-2">Vence</th>
+              <th className="text-left px-3 py-2">Creada</th>
+              <th className="text-left px-3 py-2">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((t) => (
+              <tr key={t.id} className="border-t">
+                <td className="px-3 py-2">{t.title}</td>
+                <td className="px-3 py-2">{t.status}</td>
+                <td className="px-3 py-2">{t.due_date || "—"}</td>
+                <td className="px-3 py-2">{new Date(t.created_at).toLocaleString()}</td>
+                <td className="px-3 py-2">
+                  <div className="flex gap-2">
+                    <button className="border rounded px-2 py-1" onClick={() => setStatus(t.id, "in_progress")}>
+                      En curso
+                    </button>
+                    <button className="border rounded px-2 py-1" onClick={() => setStatus(t.id, "done")}>
+                      Hecha
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {!tasks.length && (
+              <tr>
+                <td className="px-3 py-6 text-center" colSpan={5}>
+                  Sin tareas
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/components/tasks/TaskTemplateEditor.tsx
+++ b/components/tasks/TaskTemplateEditor.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function TaskTemplateEditor({
+  orgId,
+  moduleName,
+}: {
+  orgId: string;
+  moduleName: string;
+}) {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState<any>({});
+  const [list, setList] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    const p = new URLSearchParams({ org_id: orgId, module: moduleName });
+    const r = await fetch(`/api/tasks/templates?${p.toString()}`);
+    const j = await r.json();
+    setList(j?.ok ? j.data : []);
+  }
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, moduleName]);
+
+  async function save() {
+    setLoading(true);
+    const r = await fetch("/api/tasks/templates", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, module: moduleName, title, content }),
+    });
+    const j = await r.json();
+    setLoading(false);
+    if (!j.ok) alert(j.error?.message ?? "Error");
+    else {
+      setTitle("");
+      setContent({});
+      load();
+    }
+  }
+
+  async function remove(id: string) {
+    const r = await fetch("/api/tasks/templates", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id, org_id: orgId }),
+    });
+    const j = await r.json();
+    if (!j.ok) alert(j.error?.message ?? "Error");
+    else load();
+  }
+
+  return (
+    <section className="border rounded-2xl p-4 space-y-4">
+      <h3 className="font-semibold">Plantillas de tareas</h3>
+      <div className="grid md:grid-cols-3 gap-3">
+        <div className="md:col-span-2">
+          <label className="block text-sm">Título</label>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Ej. Ejercicios respiratorios (7 días)"
+          />
+        </div>
+        <div className="md:col-span-1">
+          <label className="block text-sm">Contenido (JSON)</label>
+          <textarea
+            className="border rounded px-3 py-2 w-full h-24"
+            value={JSON.stringify(content)}
+            onChange={(e) => {
+              try {
+                setContent(JSON.parse(e.target.value || "{}"));
+              } catch {
+                /* ignore */
+              }
+            }}
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button className="border rounded px-3 py-2" onClick={save} disabled={loading}>
+          Guardar plantilla
+        </button>
+      </div>
+
+      <div className="rounded border overflow-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-3 py-2">Título</th>
+              <th className="text-left px-3 py-2">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((x) => (
+              <tr key={x.id} className="border-t">
+                <td className="px-3 py-2">{x.title}</td>
+                <td className="px-3 py-2">
+                  <button className="border rounded px-3 py-1" onClick={() => remove(x.id)}>
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!list.length && (
+              <tr>
+                <td className="px-3 py-6 text-center" colSpan={2}>
+                  Sin plantillas
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/lib/branding/letterhead.ts
+++ b/lib/branding/letterhead.ts
@@ -1,0 +1,60 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** Intenta resolver un membrete del bucket 'letterheads' con el user_id. */
+export async function getUserLetterheadURL(
+  supa: SupabaseClient,
+  userId: string
+): Promise<string | null> {
+  try {
+    const bucket = supa.storage.from("letterheads");
+    const tryKeys = [`${userId}.png`, `${userId}.jpg`, `${userId}.jpeg`, `${userId}.webp`];
+    for (const key of tryKeys) {
+      const { data, error } = await bucket.createSignedUrl(key, 60);
+      if (!error && data?.signedUrl) return data.signedUrl;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Bloque HTML del membrete (imagen si existe, de lo contrario texto con datos del especialista/organización). */
+export function renderLetterheadHTML(opts: {
+  specialistName: string;
+  specialty?: string | null;
+  orgName?: string | null;
+  letterheadUrl?: string | null;
+}) {
+  const { specialistName, specialty, orgName, letterheadUrl } = opts;
+  if (letterheadUrl) {
+    return `
+      <div style="margin-bottom:16px; border-bottom:1px solid #e5e7eb; padding-bottom:12px;">
+        <img src="${letterheadUrl}" alt="Membrete" style="max-width:100%; height:auto;"/>
+      </div>
+    `;
+  }
+  return `
+    <div style="margin-bottom:16px; border-bottom:1px solid #e5e7eb; padding-bottom:8px;">
+      <div style="font-weight:700; font-size:18px;">${escapeHtml(specialistName)}</div>
+      ${
+        specialty
+          ? `<div style="color:#334155; font-size:13px;">${escapeHtml(specialty)}</div>`
+          : ""
+      }
+      ${
+        orgName
+          ? `<div style="color:#475569; font-size:12px; margin-top:4px;">${escapeHtml(orgName)}</div>`
+          : ""
+      }
+    </div>
+  `;
+}
+
+function escapeHtml(s: string) {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}


### PR DESCRIPTION
## Summary
- add helpers to resolve specialist letterheads and render printable prescription header
- introduce printable prescription page and patient autocomplete endpoint/component
- implement patient task templates, assignment APIs, and associated client panels

## Testing
- pnpm lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad82486ac832a8fea16d9c2cea3c1