### PR TITLE
Add Sonrisa budget workflows

### DIFF
--- a/app/(app)/modulos/sonrisa/presupuestos/page.tsx
+++ b/app/(app)/modulos/sonrisa/presupuestos/page.tsx
@@ -1,0 +1,44 @@
+// app/(app)/modulos/sonrisa/presupuestos/page.tsx
+"use client";
+import AccentHeader from "@/components/ui/AccentHeader";
+import BudgetEditor from "@/components/sonrisa/BudgetEditor";
+import { useMemo, useState } from "react";
+import { getActiveOrg } from "@/lib/org-local";
+import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
+import BudgetList from "@/components/sonrisa/BudgetList";
+
+export default function SonrisaPresupuestosPage() {
+  const org = useMemo(() => getActiveOrg(), []);
+  const orgId = org?.id || "";
+  const [patient, setPatient] = useState<{ id: string; label: string } | null>(null);
+
+  return (
+    <main className="p-6 md:p-10 space-y-6">
+      <AccentHeader
+        title="Sonrisa — Presupuestos"
+        subtitle="Arma presupuestos por paciente, firma de aceptación y envío a pago."
+        emojiToken="sonrisa"
+      />
+
+      <section className="rounded-2xl border p-4 space-y-3">
+        <h3 className="font-semibold">Filtrar por paciente</h3>
+        {!orgId ? (
+          <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
+            Selecciona una organización activa.
+          </p>
+        ) : (
+          <PatientAutocomplete orgId={orgId} scope="mine" onSelect={setPatient} placeholder="Buscar paciente…" />
+        )}
+        {patient && (
+          <div className="text-sm text-slate-600">
+            Paciente: <strong>{patient.label}</strong>
+          </div>
+        )}
+      </section>
+
+      {orgId && <BudgetList orgId={orgId} patientId={patient?.id || undefined} />}
+
+      <BudgetEditor />
+    </main>
+  );
+}

--- a/app/api/modules/sonrisa/quotes/accept/route.ts
+++ b/app/api/modules/sonrisa/quotes/accept/route.ts
@@ -1,0 +1,72 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/modules/sonrisa/quotes/accept
+// { org_id, quote_id, signature_data_url }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    quote_id?: string;
+    signature_data_url?: string;
+  };
+  if (!body?.org_id || !body?.quote_id || !body?.signature_data_url) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "BAD_REQUEST", message: "org_id, quote_id y signature_data_url son requeridos" },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Validar existencia y pertenencia
+  const { data: quote, error: e1 } = await supa
+    .from("sonrisa_quotes")
+    .select("id, org_id, status")
+    .eq("id", body.quote_id)
+    .eq("org_id", body.org_id)
+    .single();
+
+  if (e1) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Presupuesto no encontrado" } },
+      { status: 404 },
+    );
+  }
+  if (quote!.status === "accepted" || quote!.status === "paid") {
+    return NextResponse.json(
+      { ok: false, error: { code: "ALREADY_ACCEPTED", message: "Ya aceptado/pagado" } },
+      { status: 409 },
+    );
+  }
+
+  const { data, error } = await supa
+    .from("sonrisa_quotes")
+    .update({
+      status: "accepted",
+      signed_at: new Date().toISOString(),
+      signed_by: u.user.id,
+      signature_data_url: String(body.signature_data_url).slice(0, 1_000_000), // límite prudente
+    })
+    .eq("id", body.quote_id)
+    .select("id, status, signed_at, total_cents")
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/modules/sonrisa/quotes/create/route.ts
+++ b/app/api/modules/sonrisa/quotes/create/route.ts
@@ -1,0 +1,83 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/modules/sonrisa/quotes/create
+// { org_id, patient_id, currency?, items:[{ description, qty, unit_price_cents, treatment_id? }], notes? }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    patient_id?: string;
+    currency?: string;
+    notes?: string;
+    items?: Array<{ description?: string; qty?: number; unit_price_cents?: number; treatment_id?: string | null }>;
+  };
+  if (!body?.org_id || !body?.patient_id || !Array.isArray(body.items) || !body.items.length) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id, patient_id e items requeridos" } },
+      { status: 400 },
+    );
+  }
+
+  const currency = (body.currency || "mxn").toLowerCase();
+
+  const { data: quote, error: e1 } = await supa
+    .from("sonrisa_quotes")
+    .insert({
+      org_id: body.org_id,
+      patient_id: body.patient_id,
+      currency,
+      status: "draft",
+      notes: body.notes ? String(body.notes).slice(0, 2000) : null,
+      created_by: u.user.id,
+    })
+    .select("id")
+    .single();
+
+  if (e1) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e1.message } },
+      { status: 400 },
+    );
+  }
+
+  const items = body.items.map((it) => ({
+    quote_id: quote!.id,
+    treatment_id: it.treatment_id ?? null,
+    description: String(it.description || "").slice(0, 300),
+    qty: Math.max(1, Math.floor(Number(it.qty || 1))),
+    unit_price_cents: Math.max(0, Math.floor(Number(it.unit_price_cents || 0))),
+  }));
+
+  const { error: e2 } = await supa.from("sonrisa_quote_items").insert(items);
+  if (e2) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e2.message } },
+      { status: 400 },
+    );
+  }
+
+  // total se recalcula con trigger. Devolvemos datos resumidos:
+  const { data: q2, error: e3 } = await supa
+    .from("sonrisa_quotes")
+    .select("id, org_id, patient_id, status, currency, total_cents, created_at")
+    .eq("id", quote!.id)
+    .single();
+
+  if (e3) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e3.message } },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ ok: true, data: q2 });
+}

--- a/app/api/modules/sonrisa/quotes/list/route.ts
+++ b/app/api/modules/sonrisa/quotes/list/route.ts
@@ -1,0 +1,45 @@
+// MODE: session (user-scoped, cookies)
+// GET /api/modules/sonrisa/quotes/list?org_id&patient_id?&status?
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  if (!org_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id requerido" } },
+      { status: 400 },
+    );
+  }
+
+  let q = supa
+    .from("sonrisa_quotes")
+    .select("id, org_id, patient_id, status, currency, total_cents, notes, signed_at, created_at")
+    .eq("org_id", org_id)
+    .order("created_at", { ascending: false });
+
+  const pid = url.searchParams.get("patient_id");
+  if (pid) q = q.eq("patient_id", pid);
+
+  const status = url.searchParams.get("status");
+  if (status) q = q.eq("status", status);
+
+  const { data, error } = await q.limit(200);
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/modules/sonrisa/quotes/stripe/checkout/route.ts
+++ b/app/api/modules/sonrisa/quotes/stripe/checkout/route.ts
@@ -1,0 +1,83 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/modules/sonrisa/quotes/stripe/checkout
+// { org_id, quote_id, success_url, cancel_url }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const secret = process.env.STRIPE_SECRET_KEY;
+  if (!secret) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_CONFIGURED", message: "Stripe no configurado" } },
+      { status: 501 },
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    quote_id?: string;
+    success_url?: string;
+    cancel_url?: string;
+  };
+  if (!body?.org_id || !body?.quote_id || !body?.success_url || !body?.cancel_url) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "BAD_REQUEST", message: "org_id, quote_id, success_url y cancel_url requeridos" },
+      },
+      { status: 400 },
+    );
+  }
+
+  // obtener total
+  const { data: q, error: e1 } = await supa
+    .from("sonrisa_quotes")
+    .select("id, org_id, total_cents, currency, status")
+    .eq("id", body.quote_id)
+    .eq("org_id", body.org_id)
+    .single();
+
+  if (e1 || !q) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Presupuesto no encontrado" } },
+      { status: 404 },
+    );
+  }
+  if (!q.total_cents || q.total_cents <= 0) {
+    return NextResponse.json(
+      { ok: false, error: { code: "EMPTY_TOTAL", message: "Total inválido" } },
+      { status: 400 },
+    );
+  }
+
+  // Crear checkout
+  const stripe = new (await import("stripe")).default(secret, { apiVersion: "2024-06-20" });
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    success_url: body.success_url,
+    cancel_url: body.cancel_url,
+    currency: (q.currency || "mxn").toLowerCase(),
+    line_items: [
+      {
+        quantity: 1,
+        price_data: {
+          currency: (q.currency || "mxn").toLowerCase(),
+          product_data: { name: `Presupuesto dental #${q.id}` },
+          unit_amount: q.total_cents,
+        },
+      },
+    ],
+    metadata: { quote_id: q.id, org_id: q.org_id, module: "sonrisa" },
+  });
+
+  return NextResponse.json({ ok: true, data: { id: session.id, url: session.url } });
+}

--- a/app/api/modules/sonrisa/treatments/list/route.ts
+++ b/app/api/modules/sonrisa/treatments/list/route.ts
@@ -1,0 +1,45 @@
+// MODE: session (user-scoped, cookies)
+// GET /api/modules/sonrisa/treatments/list?org_id&q?&active?
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const org_id = url.searchParams.get("org_id");
+  if (!org_id) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id requerido" } },
+      { status: 400 },
+    );
+  }
+
+  let q = supa
+    .from("sonrisa_treatments")
+    .select("id, org_id, code, name, default_price_cents, active")
+    .eq("org_id", org_id)
+    .order("name", { ascending: true });
+
+  const active = url.searchParams.get("active");
+  if (active === "true") q = q.eq("active", true);
+  const search = url.searchParams.get("q");
+  if (search) q = q.ilike("name", `%${search}%`);
+
+  const { data, error } = await q.limit(500);
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, data });
+}

--- a/app/api/modules/sonrisa/treatments/upsert/route.ts
+++ b/app/api/modules/sonrisa/treatments/upsert/route.ts
@@ -1,0 +1,50 @@
+// MODE: session (user-scoped, cookies)
+// POST /api/modules/sonrisa/treatments/upsert
+// Body: { org_id, items: [{ id?, code, name, default_price_cents, active? }] }
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: u } = await supa.auth.getUser();
+  if (!u?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 },
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    items?: Array<{ id?: string; code?: string; name?: string; default_price_cents?: number; active?: boolean }>;
+  };
+  if (!body?.org_id || !Array.isArray(body.items) || !body.items.length) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id e items requeridos" } },
+      { status: 400 },
+    );
+  }
+
+  const rows = body.items.map((x) => ({
+    id: x.id ?? undefined,
+    org_id: body.org_id!,
+    code: String(x.code || "").slice(0, 64),
+    name: String(x.name || "").slice(0, 200),
+    default_price_cents: Number(x.default_price_cents || 0),
+    active: x.active ?? true,
+    created_by: u.user!.id,
+  }));
+
+  const { data, error } = await supa
+    .from("sonrisa_treatments")
+    .upsert(rows, { onConflict: "org_id,code" })
+    .select("id, org_id, code, name, default_price_cents, active");
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ ok: true, data });
+}

--- a/components/patients/PatientAutocomplete.tsx
+++ b/components/patients/PatientAutocomplete.tsx
@@ -1,0 +1,127 @@
+// components/patients/PatientAutocomplete.tsx
+"use client";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type Option = {
+  id: string;
+  name: string | null;
+  dob?: string | null;
+  gender?: string | null;
+};
+
+type Props = {
+  orgId: string;
+  scope?: string;
+  placeholder?: string;
+  onSelect: (value: { id: string; label: string }) => void;
+};
+
+export default function PatientAutocomplete({ orgId, scope, placeholder, onSelect }: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Option[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (!boxRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  useEffect(() => {
+    if (!orgId) {
+      setResults([]);
+      return;
+    }
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      return;
+    }
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => {
+      const params = new URLSearchParams({ org_id: orgId, q: trimmed, pageSize: "10" });
+      if (scope) params.set("scope", scope);
+      setLoading(true);
+      fetch(`/api/patients/search?${params.toString()}`, { signal: ctrl.signal })
+        .then((r) => r.json())
+        .then((j) => {
+          if (!ctrl.signal.aborted) {
+            setResults(j?.ok ? j.data ?? [] : []);
+            setOpen(true);
+          }
+        })
+        .catch((err) => {
+          if (err?.name !== "AbortError") {
+            console.error("PatientAutocomplete", err);
+          }
+        })
+        .finally(() => !ctrl.signal.aborted && setLoading(false));
+    }, 250);
+
+    return () => {
+      clearTimeout(timer);
+      ctrl.abort();
+    };
+  }, [orgId, query, scope]);
+
+  const hasResults = results.length > 0;
+
+  const helpText = useMemo(() => {
+    if (!orgId) return "Selecciona una organización";
+    if (query.trim().length < 2) return "Escribe al menos 2 caracteres";
+    if (loading) return "Buscando…";
+    if (!hasResults) return "Sin coincidencias";
+    return "";
+  }, [orgId, query, loading, hasResults]);
+
+  return (
+    <div className="space-y-1" ref={boxRef}>
+      <input
+        className="border rounded px-3 py-2 w-full"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder={placeholder ?? "Buscar paciente"}
+        disabled={!orgId}
+        onFocus={() => query.trim().length >= 2 && setOpen(true)}
+        autoComplete="off"
+      />
+      {helpText && <p className="text-xs text-slate-500">{helpText}</p>}
+      {open && hasResults && (
+        <ul className="border rounded-lg bg-white shadow divide-y max-h-64 overflow-auto">
+          {results.map((r) => {
+            const label = r.name ? String(r.name) : "Paciente sin nombre";
+            return (
+              <li key={r.id}>
+                <button
+                  type="button"
+                  className="w-full text-left px-3 py-2 hover:bg-slate-100"
+                  onClick={() => {
+                    onSelect({ id: r.id, label });
+                    setQuery(label);
+                    setOpen(false);
+                  }}
+                >
+                  <div className="font-medium">{label}</div>
+                  {(r.gender || r.dob) && (
+                    <div className="text-xs text-slate-500">
+                      {[r.gender, r.dob ? new Date(r.dob).toLocaleDateString() : null]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </div>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/sonrisa/BudgetEditor.tsx
+++ b/components/sonrisa/BudgetEditor.tsx
@@ -1,0 +1,206 @@
+// components/sonrisa/BudgetEditor.tsx
+"use client";
+import { useMemo, useState } from "react";
+import CatalogPicker from "./CatalogPicker";
+import SignaturePad from "./SignaturePad";
+import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
+import { getActiveOrg } from "@/lib/org-local";
+
+type Item = { description: string; qty: number; unit_price_cents: number; treatment_id?: string };
+
+export default function BudgetEditor() {
+  const org = useMemo(() => getActiveOrg(), []);
+  const orgId = org?.id || "";
+
+  const [patient, setPatient] = useState<{ id: string; label: string } | null>(null);
+  const [items, setItems] = useState<Item[]>([]);
+  const [notes, setNotes] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+  const [lastQuoteId, setLastQuoteId] = useState<string | null>(null);
+  const [signature, setSignature] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+
+  const totalCents = useMemo(() => items.reduce((s, it) => s + it.qty * it.unit_price_cents, 0), [items]);
+
+  function add(it: Item) {
+    setItems((xs) => [...xs, it]);
+  }
+  function del(i: number) {
+    setItems((xs) => xs.filter((_, idx) => idx !== i));
+  }
+  function setQty(i: number, q: number) {
+    setItems((xs) => xs.map((x, idx) => (idx === i ? { ...x, qty: Math.max(1, Math.floor(q)) } : x)));
+  }
+  function setPrice(i: number, p: number) {
+    setItems((xs) => xs.map((x, idx) => (idx === i ? { ...x, unit_price_cents: Math.max(0, Math.floor(p)) } : x)));
+  }
+
+  async function save() {
+    if (!orgId || !patient?.id) {
+      alert("Falta organización o paciente");
+      return;
+    }
+    if (!items.length) {
+      alert("Agrega al menos un concepto");
+      return;
+    }
+    setSaving(true);
+    const r = await fetch("/api/modules/sonrisa/quotes/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, patient_id: patient.id, items, notes }),
+    });
+    const j = await r.json();
+    setSaving(false);
+    if (!j.ok) {
+      alert(j.error?.message ?? "Error");
+      return;
+    }
+    setLastQuoteId(j.data.id);
+    alert("Presupuesto guardado. Ahora puedes firmar con el paciente.");
+  }
+
+  async function accept() {
+    if (!orgId || !lastQuoteId || !signature) {
+      alert("Falta firma o presupuesto");
+      return;
+    }
+    setAccepting(true);
+    const r = await fetch("/api/modules/sonrisa/quotes/accept", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, quote_id: lastQuoteId, signature_data_url: signature }),
+    });
+    const j = await r.json();
+    setAccepting(false);
+    if (!j.ok) {
+      alert(j.error?.message ?? "Error");
+      return;
+    }
+    alert("Presupuesto aceptado y firmado ✅");
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="border rounded-2xl p-4 space-y-3">
+        <h3 className="font-semibold">Paciente</h3>
+        {!orgId ? (
+          <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
+            Selecciona una organización activa.
+          </p>
+        ) : (
+          <PatientAutocomplete orgId={orgId} scope="mine" onSelect={setPatient} placeholder="Buscar paciente…" />
+        )}
+        {patient && (
+          <div className="text-sm text-slate-600">
+            Paciente: <strong>{patient.label}</strong>
+          </div>
+        )}
+      </div>
+
+      <CatalogPicker orgId={orgId} onAdd={add} />
+
+      <div className="border rounded-2xl p-4 space-y-3">
+        <h3 className="font-semibold">Renglones</h3>
+        <div className="rounded border overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-3 py-2">Descripción</th>
+                <th className="text-right px-3 py-2">Cantidad</th>
+                <th className="text-right px-3 py-2">Precio</th>
+                <th className="text-right px-3 py-2">Importe</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-2">{it.description}</td>
+                  <td className="px-3 py-2 text-right">
+                    <input
+                      className="border rounded px-2 py-1 w-20 text-right"
+                      inputMode="numeric"
+                      value={it.qty}
+                      onChange={(e) => setQty(i, Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <input
+                      className="border rounded px-2 py-1 w-28 text-right"
+                      inputMode="numeric"
+                      value={Math.round(it.unit_price_cents)}
+                      onChange={(e) => setPrice(i, Number(e.target.value))}
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {((it.qty * it.unit_price_cents) / 100).toLocaleString("es-MX", {
+                      style: "currency",
+                      currency: "MXN",
+                    })}
+                  </td>
+                  <td className="px-3 py-2">
+                    <button className="border rounded px-2 py-1" onClick={() => del(i)}>
+                      Quitar
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {!items.length && (
+                <tr>
+                  <td colSpan={5} className="px-3 py-6 text-center text-slate-500">
+                    Agrega tratamientos desde el catálogo
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <label className="text-sm">Notas</label>
+            <textarea
+              className="border rounded px-3 py-2 w-full min-h-[80px]"
+              placeholder="Condiciones, vigencia, observaciones…"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </div>
+          <div className="text-right min-w-[220px] pl-4">
+            <div className="text-sm text-slate-500">Total</div>
+            <div className="text-2xl font-semibold">
+              {(totalCents / 100).toLocaleString("es-MX", { style: "currency", currency: "MXN" })}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <button className="border rounded px-3 py-2" onClick={save} disabled={saving || !patient}>
+            Guardar presupuesto
+          </button>
+        </div>
+      </div>
+
+      {lastQuoteId && (
+        <div className="border rounded-2xl p-4 space-y-3">
+          <h3 className="font-semibold">Firma del paciente</h3>
+          <SignaturePad onChange={setSignature} />
+          <div className="flex gap-2">
+            <button className="border rounded px-3 py-2" disabled={!signature || accepting} onClick={accept}>
+              Aceptar y firmar
+            </button>
+            {/* Opcional: pago */}
+            <form action="/api/modules/sonrisa/quotes/stripe/checkout" method="post" className="inline-flex gap-2">
+              <input type="hidden" name="org_id" value={orgId} />
+              <input type="hidden" name="quote_id" value={lastQuoteId} />
+            </form>
+          </div>
+          <p className="text-xs text-slate-500">
+            Al firmar, se registra la aceptación con sello de tiempo y usuario.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/sonrisa/BudgetList.tsx
+++ b/components/sonrisa/BudgetList.tsx
@@ -1,0 +1,74 @@
+// components/sonrisa/BudgetList.tsx
+"use client";
+import { useEffect, useState } from "react";
+
+type Row = { id: string; status: string; total_cents: number; currency: string; created_at: string; signed_at?: string | null };
+
+export default function BudgetList({ orgId, patientId }: { orgId: string; patientId?: string }) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [status, setStatus] = useState<string>("");
+
+  async function load() {
+    const p = new URLSearchParams({ org_id: orgId });
+    if (patientId) p.set("patient_id", patientId);
+    if (status) p.set("status", status);
+    const r = await fetch(`/api/modules/sonrisa/quotes/list?${p.toString()}`, { cache: "no-store" });
+    const j = await r.json();
+    setRows(j?.ok ? j.data : []);
+  }
+  useEffect(() => {
+    if (orgId) load();
+  }, [orgId, patientId, status]);
+
+  return (
+    <section className="border rounded-2xl p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <select className="border rounded px-3 py-2" value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">Todos</option>
+          <option value="draft">Borrador</option>
+          <option value="accepted">Aceptado</option>
+          <option value="paid">Pagado</option>
+          <option value="rejected">Rechazado</option>
+        </select>
+        <button className="border rounded px-3 py-2" onClick={load}>
+          Actualizar
+        </button>
+      </div>
+      <div className="rounded border overflow-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-3 py-2">Fecha</th>
+              <th className="text-left px-3 py-2">Estatus</th>
+              <th className="text-right px-3 py-2">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="px-3 py-2">{new Date(r.created_at).toLocaleString()}</td>
+                <td className="px-3 py-2">
+                  {r.status}
+                  {r.signed_at ? " (firmado)" : ""}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {(r.total_cents / 100).toLocaleString("es-MX", {
+                    style: "currency",
+                    currency: (r.currency || "mxn").toUpperCase(),
+                  })}
+                </td>
+              </tr>
+            ))}
+            {!rows.length && (
+              <tr>
+                <td colSpan={3} className="px-3 py-6 text-center text-slate-500">
+                  Sin presupuestos
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/components/sonrisa/CatalogPicker.tsx
+++ b/components/sonrisa/CatalogPicker.tsx
@@ -1,0 +1,79 @@
+// components/sonrisa/CatalogPicker.tsx
+"use client";
+import { useEffect, useState } from "react";
+
+type Row = { id: string; code: string; name: string; default_price_cents: number; active: boolean };
+
+export default function CatalogPicker({
+  orgId,
+  onAdd,
+}: {
+  orgId: string;
+  onAdd: (item: { description: string; qty: number; unit_price_cents: number; treatment_id?: string }) => void;
+}) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [q, setQ] = useState("");
+
+  async function load() {
+    const p = new URLSearchParams({ org_id: orgId, active: "true" });
+    if (q) p.set("q", q);
+    const r = await fetch(`/api/modules/sonrisa/treatments/list?${p.toString()}`, { cache: "no-store" });
+    const j = await r.json();
+    setRows(j?.ok ? j.data : []);
+  }
+
+  useEffect(() => {
+    if (orgId) load();
+  }, [orgId, q]);
+
+  return (
+    <div className="border rounded-2xl p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <input
+          className="border rounded px-3 py-2 flex-1"
+          placeholder="Buscar tratamiento…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <button className="border rounded px-3 py-2" onClick={load}>
+          Buscar
+        </button>
+      </div>
+      <div className="rounded border overflow-auto max-h-72">
+        <table className="w-full text-sm">
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-b">
+                <td className="px-3 py-2 w-24 text-xs text-slate-500">{r.code}</td>
+                <td className="px-3 py-2">{r.name}</td>
+                <td className="px-3 py-2 w-32 text-right">
+                  {(r.default_price_cents / 100).toLocaleString("es-MX", { style: "currency", currency: "MXN" })}
+                </td>
+                <td className="px-3 py-2 w-28 text-right">
+                  <button
+                    className="border rounded px-3 py-1"
+                    onClick={() =>
+                      onAdd({
+                        description: r.name,
+                        qty: 1,
+                        unit_price_cents: r.default_price_cents,
+                        treatment_id: r.id,
+                      })
+                    }
+                  >
+                    Agregar
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!rows.length && (
+              <tr>
+                <td className="px-3 py-6 text-center text-slate-500">Sin resultados</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/sonrisa/SignaturePad.tsx
+++ b/components/sonrisa/SignaturePad.tsx
@@ -1,0 +1,80 @@
+// components/sonrisa/SignaturePad.tsx
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export default function SignaturePad({
+  onChange,
+  width = 600,
+  height = 200,
+}: {
+  onChange?: (dataUrl: string | null) => void;
+  width?: number;
+  height?: number;
+}) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const [drawing, setDrawing] = useState(false);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }, []);
+
+  function pos(e: React.MouseEvent | React.TouchEvent) {
+    const c = ref.current!;
+    const r = c.getBoundingClientRect();
+    const touch = "touches" in e ? e.touches[0] : (e as any);
+    return { x: touch.clientX - r.left, y: touch.clientY - r.top };
+  }
+
+  function start(e: any) {
+    setDrawing(true);
+  }
+  function end() {
+    setDrawing(false);
+    const c = ref.current!;
+    onChange?.(c.toDataURL("image/png"));
+  }
+  function move(e: any) {
+    if (!drawing) return;
+    const c = ref.current!;
+    const ctx = c.getContext("2d")!;
+    const { x, y } = pos(e);
+    ctx.fillStyle = "#000";
+    ctx.beginPath();
+    ctx.arc(x, y, 1.6, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  function clear() {
+    const c = ref.current!;
+    const ctx = c.getContext("2d")!;
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, c.width, c.height);
+    onChange?.(null);
+  }
+
+  return (
+    <div className="space-y-2">
+      <canvas
+        ref={ref}
+        width={width}
+        height={height}
+        className="border rounded-xl w-full touch-none bg-white"
+        onMouseDown={start}
+        onMouseUp={end}
+        onMouseMove={move}
+        onMouseLeave={end}
+        onTouchStart={start}
+        onTouchEnd={end}
+        onTouchMove={move}
+      />
+      <div className="flex gap-2">
+        <button className="border rounded px-3 py-2" onClick={clear}>
+          Limpiar
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoints to gestionar tratamientos y presupuestos del módulo Sonrisa, incluyendo creación, aceptación y checkout con Stripe
- incorporar componentes cliente para catálogo de tratamientos, lista de presupuestos y captura de firma
- publicar una página de presupuestos para Sonrisa con filtros por paciente y editor integrado

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad917f6c4832a8cc8c79952c8cadf