### PR TITLE
feat: enhance prescriptions flows

### DIFF
--- a/app/(app)/modulos/recetas/page.tsx
+++ b/app/(app)/modulos/recetas/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import AccentHeader from "@/components/ui/AccentHeader";
+import PrescriptionEditor from "@/components/prescriptions/PrescriptionEditor";
+
+export default function RecetasPage() {
+  return (
+    <main className="p-6 md:p-10 space-y-6">
+      <AccentHeader
+        title="Recetas médicas"
+        subtitle="Crea recetas con membrete y firma, reutiliza plantillas y exporta a impresión."
+        emojiToken="receta"
+      />
+      <PrescriptionEditor />
+    </main>
+  );
+}

--- a/app/(app)/print/recetas/[id]/page.tsx
+++ b/app/(app)/print/recetas/[id]/page.tsx
@@ -1,0 +1,90 @@
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export default async function PrintRecetaPage({ params }: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return <div className="p-6 text-rose-700">Necesitas iniciar sesión.</div>;
+  }
+
+  const id = params.id;
+  const { data: rec } = await supa
+    .from("prescriptions")
+    .select("id, org_id, patient_id, clinician_id, letterhead_path, signature_path, notes, issued_at")
+    .eq("id", id)
+    .single();
+  const { data: items } = await supa
+    .from("prescription_items")
+    .select("drug, dose, route, frequency, duration, instructions")
+    .eq("prescription_id", id)
+    .order("created_at", { ascending: true });
+
+  if (!rec) {
+    return <div className="p-6 text-rose-700">No se encontró la receta.</div>;
+  }
+
+  return (
+    <main className="p-6 print:p-0 text-slate-900">
+      <section className="max-w-[800px] mx-auto space-y-4">
+        {rec.letterhead_path ? (
+          <img
+            src={`/api/storage/letterheads/${encodeURIComponent(rec.letterhead_path)}`}
+            alt="Membrete"
+            className="w-full rounded-xl border"
+          />
+        ) : null}
+
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold">Receta</h1>
+            <p className="text-sm text-slate-500">
+              Emitida: {rec.issued_at ? new Date(rec.issued_at).toLocaleString() : "—"}
+            </p>
+            {rec.notes ? <p className="text-sm text-slate-600 mt-1">Notas: {rec.notes}</p> : null}
+          </div>
+          <div className="text-right">
+            {rec.signature_path ? (
+              <>
+                <img
+                  src={`/api/storage/signatures/${encodeURIComponent(rec.signature_path)}`}
+                  alt="Firma"
+                  className="h-20 inline-block"
+                />
+                <div className="text-xs text-slate-500">Firma del especialista</div>
+              </>
+            ) : null}
+          </div>
+        </header>
+
+        <section className="rounded-2xl border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="text-left px-3 py-2 w-1/4">Fármaco</th>
+                <th className="text-left px-3 py-2 w-1/4">Dosis / Vía</th>
+                <th className="text-left px-3 py-2 w-1/4">Frecuencia / Duración</th>
+                <th className="text-left px-3 py-2 w-1/4">Indicaciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(items || []).map((it, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-2">
+                    <strong>{it.drug}</strong>
+                  </td>
+                  <td className="px-3 py-2">
+                    {it.dose || ""} {it.route ? `/ ${it.route}` : ""}
+                  </td>
+                  <td className="px-3 py-2">
+                    {it.frequency || ""} {it.duration ? `/ ${it.duration}` : ""}
+                  </td>
+                  <td className="px-3 py-2">{it.instructions || ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/app/api/prescriptions/[id]/pdf/route.ts
+++ b/app/api/prescriptions/[id]/pdf/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
 import { newPdf, pngFromDataUrl, makeQrDataUrl, drawWrappedText } from "@/lib/pdf";
 
 async function signedBuf(supabase: any, bucket: string, key: string) {
@@ -12,11 +11,85 @@ async function signedBuf(supabase: any, bucket: string, key: string) {
   return await r.arrayBuffer();
 }
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const id = params.id;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await getSupabaseServer();
+  const { data: au } = await supabase.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
 
-  // Cabecera de receta
+  const url = new URL(req.url);
+  if (url.searchParams.get("format") === "html") {
+    const origin = url.origin;
+    const jsonUrl = `${origin}/api/prescriptions/${params.id}/json`;
+    const res = await fetch(jsonUrl, {
+      cache: "no-store",
+      headers: { cookie: req.headers.get("cookie") || "" },
+    });
+    const j = await res.json();
+    if (!j?.ok) {
+      return NextResponse.json(j?.error || { code: "NOT_FOUND", message: "No encontrada" }, {
+        status: res.status || 400,
+      });
+    }
+
+    const html = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Receta ${params.id}</title>
+<style>
+  body{ font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto; color:#0f172a; }
+  .sheet{ width: 800px; margin: 24px auto; }
+  .row{ display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
+  .h{ font-weight:600; font-size:18px; }
+  .muted{ color:#64748b; font-size:12px; }
+  .box{ border:1px solid #e2e8f0; border-radius:12px; padding:16px; }
+  .items td{ padding:8px; border-bottom: 1px solid #e2e8f0; vertical-align: top;}
+  .w-25{ width:25%; } .w-50{ width:50%; }
+  img{ max-width:100%; }
+</style>
+</head>
+<body>
+  <div class="sheet">
+    ${j.data.letterhead_path ? `<div class="box"><img src="${origin}/api/storage/letterheads/${encodeURIComponent(j.data.letterhead_path)}" alt="Membrete" /></div>` : ""}
+    <div class="row" style="margin-top:16px">
+      <div class="w-50">
+        <div class="h">Receta</div>
+        <div class="muted">Emitida: ${j.data.issued_at ? new Date(j.data.issued_at).toLocaleString() : "—"}</div>
+        ${j.data.notes ? `<div class="muted" style="margin-top:4px">Notas: ${j.data.notes}</div>` : ""}
+      </div>
+      <div class="w-50" style="text-align:right">
+        ${j.data.signature_path ? `<img style="max-height:80px" src="${origin}/api/storage/signatures/${encodeURIComponent(j.data.signature_path)}" alt="Firma" />` : ""}
+        <div class="muted">Firma del especialista</div>
+      </div>
+    </div>
+    <div class="box" style="margin-top:16px">
+      <table class="items" style="width:100%; border-collapse:collapse;">
+        <thead><tr><th class="w-25" style="text-align:left">Fármaco</th><th class="w-25" style="text-align:left">Dosis/Vía</th><th class="w-25" style="text-align:left">Frecuencia/Duración</th><th class="w-25" style="text-align:left">Indicaciones</th></tr></thead>
+        <tbody>
+          ${j.data.items.map((it: any)=>`<tr>
+            <td><strong>${it.drug}</strong></td>
+            <td>${it.dose || ""} ${it.route ? ` / ${it.route}` : ""}</td>
+            <td>${it.freq || ""} ${it.duration? ` / ${it.duration}`:""}</td>
+            <td>${it.instructions || ""}</td>
+          </tr>`).join("")}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body></html>`;
+
+    return new NextResponse(html, {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "content-disposition": `inline; filename="receta-${params.id}.html"`,
+      },
+    });
+  }
+
+  const id = params.id;
   const { data: rx } = await supabase
     .from("prescriptions")
     .select("id, org_id, patient_id, doctor_id, diagnosis, notes, created_at")
@@ -44,7 +117,6 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     .eq("doctor_id", rx.doctor_id)
     .maybeSingle();
 
-  // Disclaimer por tipo
   let footer = lh?.footer_disclaimer || "";
   if (!footer) {
     const { data: d } = await supabase
@@ -56,7 +128,6 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     footer = d?.text || footer;
   }
 
-  // Folio + verificación
   const { data: led } = await supabase.rpc("ensure_document_folio", {
     p_doc_type: "prescription",
     p_doc_id: id,
@@ -64,17 +135,15 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   const verifyUrl = `${process.env.NEXT_PUBLIC_APP_URL || ""}/api/docs/verify?type=prescription&id=${id}&code=${led.verify_code}`;
   const qrDataUrl = await makeQrDataUrl(verifyUrl);
 
-  // PDF
   const { pdf, page, bold, W, H } = await newPdf();
   let y = H - 40;
 
-  // Encabezado con logo y datos
   if (lh?.logo_url) {
     const ab = await signedBuf(supabase, "letterheads", lh.logo_url);
     if (ab) {
       const img = await pdf.embedPng(ab);
-      const w = 120,
-        h = (img.height / img.width) * w;
+      const w = 120;
+      const h = (img.height / img.width) * w;
       page.drawImage(img, { x: 40, y: y - h + 8, width: w, height: h });
     }
   }
@@ -90,11 +159,9 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     y -= 12;
   }
 
-  // Folio/fecha
   page.drawText(`Folio: ${led.folio}`, { x: W - 160, y: H - 40, size: 10 });
   page.drawText(new Date(rx.created_at).toLocaleString(), { x: W - 160, y: H - 54, size: 10 });
 
-  // Paciente
   y -= 8;
   page.drawText("Paciente:", { x: 40, y, size: 12 });
   y -= 14;
@@ -105,7 +172,6 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     y -= 12;
   }
 
-  // Diagnóstico
   if (rx.diagnosis) {
     y -= 6;
     page.drawText("Diagnóstico:", { x: 40, y, size: 12 });
@@ -113,7 +179,6 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     y = drawWrappedText(page, rx.diagnosis, 40, y, W - 80, 10);
   }
 
-  // Items
   y -= 6;
   page.drawText("Prescripción:", { x: 40, y, size: 12 });
   y -= 14;
@@ -124,13 +189,12 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
     y -= 4;
   }
 
-  // Firma y QR
   if (lh?.signature_url) {
     const ab = await signedBuf(supabase, "signatures", lh.signature_url);
     if (ab) {
       const img = await pdf.embedPng(ab);
-      const w = 140,
-        h = (img.height / img.width) * w;
+      const w = 140;
+      const h = (img.height / img.width) * w;
       page.drawImage(img, { x: W - 40 - w, y: 90, width: w, height: h });
     }
   }
@@ -138,10 +202,10 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   page.drawImage(qr, { x: W - 160, y: 40, width: 100, height: 100 });
   page.drawText("Verificar:", { x: W - 160, y: 144, size: 9 });
   page.drawText(verifyUrl.slice(0, 46), { x: W - 160, y: 132, size: 8 });
-  if (verifyUrl.length > 46)
+  if (verifyUrl.length > 46) {
     page.drawText(verifyUrl.slice(46, 92), { x: W - 160, y: 122, size: 8 });
+  }
 
-  // Pie
   if (footer) page.drawText(footer.slice(0, 300), { x: 40, y: 60, size: 9 });
 
   const bytes = await pdf.save();

--- a/app/api/prescriptions/from-template/route.ts
+++ b/app/api/prescriptions/from-template/route.ts
@@ -1,49 +1,141 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
 
-export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const body = await req.json().catch(() => null);
-  const { patient_id, template_id, diagnosis = null, notes = null } = body || {};
+type BodyInput = {
+  org_id?: string | null;
+  patient_id?: string | null;
+  template_id?: string | null;
+  clinician_id?: string | null;
+  letterhead_path?: string | null;
+  signature_path?: string | null;
+  issued_at?: string | null;
+};
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "No auth" }, { status: 401 });
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
 
-  const { data: mem } = await supabase
-    .from("organization_members")
-    .select("org_id")
-    .eq("user_id", user.id)
-    .maybeSingle();
-  const org_id = mem?.org_id;
+  const body = (await req.json().catch(() => null)) as BodyInput | null;
+  if (!body?.patient_id || !body?.template_id) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "BAD_REQUEST",
+          message: "org_id, patient_id, template_id requeridos",
+        },
+      },
+      { status: 400 }
+    );
+  }
 
-  const { data: tpl } = await supabase
+  let orgId = body.org_id ?? null;
+  if (!orgId) {
+    const { data: mem } = await supa
+      .from("organization_members")
+      .select("org_id")
+      .eq("user_id", au.user.id)
+      .maybeSingle();
+    orgId = mem?.org_id ?? null;
+  }
+
+  if (!orgId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "BAD_REQUEST",
+          message: "org_id, patient_id, template_id requeridos",
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data: tpl, error: e0 } = await supa
     .from("prescription_templates")
-    .select("*")
-    .eq("id", template_id)
+    .select("id, org_id, name, notes, items, doctor_id, created_by")
+    .eq("id", body.template_id)
+    .eq("org_id", orgId)
     .maybeSingle();
 
-  if (!tpl) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  if (e0 || !tpl) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Plantilla no encontrada" } },
+      { status: 404 }
+    );
+  }
 
-  const { data: rx, error: e1 } = await supabase
+  const issued = body.issued_at ? new Date(body.issued_at) : new Date();
+  if (Number.isNaN(issued.getTime())) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "issued_at inválido" } },
+      { status: 400 }
+    );
+  }
+
+  const payload: Record<string, any> = {
+    org_id: orgId,
+    patient_id: body.patient_id,
+    doctor_id: au.user.id,
+    notes: tpl.notes ? String(tpl.notes).slice(0, 2000) : null,
+    issued_at: issued.toISOString(),
+    created_by: au.user.id,
+  };
+
+  if (typeof body.clinician_id !== "undefined" && body.clinician_id !== null) {
+    payload.clinician_id = body.clinician_id;
+  }
+  if (typeof body.letterhead_path !== "undefined") {
+    payload.letterhead_path = body.letterhead_path ?? null;
+  }
+  if (typeof body.signature_path !== "undefined") {
+    payload.signature_path = body.signature_path ?? null;
+  }
+
+  const { data: rec, error: e1 } = await supa
     .from("prescriptions")
-    .insert({ org_id, patient_id, doctor_id: user.id, diagnosis, notes })
+    .insert(payload)
     .select("id")
     .single();
-  if (e1) return NextResponse.json({ error: "create_failed" }, { status: 500 });
 
-  const items = (tpl.items || []).map((it: any) => ({
-    prescription_id: rx.id,
-    drug: it.drug_name,
-    dose: it.dose || null,
-    route: it.route || null,
-    frequency: it.frequency || null,
-    duration: it.duration || null,
-    instructions: it.instructions || null,
-  }));
-  if (items.length) await supabase.from("prescription_items").insert(items);
+  if (e1 || !rec) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e1?.message || "Error al crear" } },
+      { status: 400 }
+    );
+  }
 
-  return NextResponse.json({ id: rx.id });
+  const tplItems = (tpl.items as any[]) || [];
+  const items = tplItems.map((it) => {
+    const name = it?.drug ?? it?.drug_name ?? "";
+    const frequency = it?.freq ?? it?.frequency ?? null;
+    return {
+      prescription_id: rec.id,
+      drug: String(name).slice(0, 200),
+      dose: it?.dose ? String(it.dose).slice(0, 120) : null,
+      route: it?.route ? String(it.route).slice(0, 80) : null,
+      frequency: frequency ? String(frequency).slice(0, 120) : null,
+      duration: it?.duration ? String(it.duration).slice(0, 120) : null,
+      instructions: it?.instructions ? String(it.instructions).slice(0, 500) : null,
+    };
+  });
+
+  if (items.length) {
+    const { error: e2 } = await supa.from("prescription_items").insert(items);
+    if (e2) {
+      return NextResponse.json(
+        { ok: false, error: { code: "DB_ERROR", message: e2.message } },
+        { status: 400 }
+      );
+    }
+  }
+
+  return NextResponse.json({ ok: true, data: { id: rec.id }, id: rec.id });
 }

--- a/app/api/prescriptions/templates/route.ts
+++ b/app/api/prescriptions/templates/route.ts
@@ -1,58 +1,186 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
 
-/** GET: lista plantillas del doctor + org */
-export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "No auth" }, { status: 401 });
+type TemplateItemInput = {
+  drug?: string;
+  drug_name?: string;
+  dose?: string;
+  route?: string;
+  freq?: string;
+  frequency?: string;
+  duration?: string;
+  instructions?: string | null;
+};
 
-  const { data: mem } = await supabase
-    .from("organization_members")
-    .select("org_id")
-    .eq("user_id", user.id)
-    .maybeSingle();
+type LegacyBody = {
+  name?: string;
+  items?: TemplateItemInput[];
+  doctor_scope?: boolean;
+  specialty?: string | null;
+};
 
-  const org_id = mem?.org_id;
-  const { data } = await supabase
-    .from("prescription_templates")
-    .select("*")
-    .eq("org_id", org_id)
-    .or(`doctor_id.is.null,doctor_id.eq.${user.id}`)
-    .order("doctor_id", { ascending: false });
+type ModernBody = {
+  org_id?: string | null;
+  name?: string;
+  notes?: string | null;
+  items?: TemplateItemInput[];
+  active?: boolean;
+};
 
-  return NextResponse.json({ items: data || [] });
+function sanitizeItems(items: TemplateItemInput[] = []) {
+  return items.map((it) => ({
+    drug: String(it?.drug ?? it?.drug_name ?? "").slice(0, 200),
+    drug_name: String(it?.drug ?? it?.drug_name ?? "").slice(0, 200),
+    dose: it?.dose ? String(it.dose).slice(0, 120) : null,
+    route: it?.route ? String(it.route).slice(0, 80) : null,
+    freq: it?.freq ? String(it.freq).slice(0, 120) : it?.frequency ? String(it.frequency).slice(0, 120) : null,
+    frequency: it?.frequency ? String(it.frequency).slice(0, 120) : it?.freq ? String(it.freq).slice(0, 120) : null,
+    duration: it?.duration ? String(it.duration).slice(0, 120) : null,
+    instructions: it?.instructions ? String(it.instructions).slice(0, 500) : null,
+  }));
 }
 
-/** POST: crear plantilla (doctor_scope=true => privada del doctor) */
-export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "No auth" }, { status: 401 });
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
 
-  const body = await req.json().catch(() => null);
-  const { name, items = [], doctor_scope = true, specialty = null } = body || {};
+  const url = new URL(req.url);
+  let orgId = url.searchParams.get("org_id");
+  if (!orgId) {
+    const { data: mem } = await supa
+      .from("organization_members")
+      .select("org_id")
+      .eq("user_id", au.user.id)
+      .maybeSingle();
+    orgId = mem?.org_id ?? undefined;
+  }
 
-  const { data: mem } = await supabase
-    .from("organization_members")
-    .select("org_id")
-    .eq("user_id", user.id)
-    .maybeSingle();
+  if (!orgId) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id requerido" } },
+      { status: 400 }
+    );
+  }
 
-  const org_id = mem?.org_id;
-  const payload = { org_id, doctor_id: doctor_scope ? user.id : null, specialty, name, items };
-
-  const { data, error } = await supabase
+  let query = supa
     .from("prescription_templates")
-    .insert(payload)
-    .select("*")
+    .select("id, org_id, name, notes, items, active, doctor_id, created_at, created_by")
+    .eq("org_id", orgId)
+    .order("created_at", { ascending: false });
+
+  const search = url.searchParams.get("q");
+  if (search) {
+    query = query.ilike("name", `%${search}%`);
+  }
+
+  const mine = url.searchParams.get("mine");
+  if (mine === "1") {
+    query = query.or(`created_by.eq.${au.user.id},doctor_id.eq.${au.user.id}`);
+  }
+
+  const { data, error } = await query.limit(200);
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, data: data ?? [], items: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const rawBody = (await req.json().catch(() => null)) as (LegacyBody & ModernBody) | null;
+  const isLegacy = !!rawBody && ("doctor_scope" in rawBody || !rawBody?.org_id);
+  const orgId = rawBody?.org_id ?? null;
+
+  let effectiveOrgId = orgId;
+  if (!effectiveOrgId) {
+    const { data: mem } = await supa
+      .from("organization_members")
+      .select("org_id")
+      .eq("user_id", au.user.id)
+      .maybeSingle();
+    effectiveOrgId = mem?.org_id ?? null;
+  }
+
+  if (!effectiveOrgId || !rawBody?.name) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id, name e items requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  const safeItems = sanitizeItems(rawBody.items || []);
+  if (!safeItems.length) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "org_id, name e items requeridos" } },
+      { status: 400 }
+    );
+  }
+
+  if (isLegacy) {
+    const payload: Record<string, any> = {
+      org_id: effectiveOrgId,
+      doctor_id: rawBody.doctor_scope === false ? null : au.user.id,
+      specialty: rawBody.specialty ?? null,
+      name: String(rawBody.name).slice(0, 200),
+      items: safeItems,
+      created_by: au.user.id,
+    };
+
+    const { data, error } = await supa
+      .from("prescription_templates")
+      .insert(payload)
+      .select("id, org_id, name, notes, items, active, doctor_id, created_at, created_by")
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { ok: false, error: { code: "DB_ERROR", message: error.message } },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({ ok: true, data, item: data });
+  }
+
+  const payload = {
+    org_id: effectiveOrgId,
+    name: String(rawBody.name).slice(0, 200),
+    notes: rawBody.notes ? String(rawBody.notes).slice(0, 2000) : null,
+    items: safeItems,
+    active: rawBody.active ?? true,
+    created_by: au.user.id,
+  };
+
+  const { data, error } = await supa
+    .from("prescription_templates")
+    .upsert(payload, { onConflict: "org_id,name" })
+    .select("id, org_id, name, notes, items, active, doctor_id, created_at, created_by")
     .single();
 
-  if (error) return NextResponse.json({ error: "create_failed" }, { status: 500 });
-  return NextResponse.json({ item: data });
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, data, item: data });
 }

--- a/components/prescriptions/PrescriptionEditor.tsx
+++ b/components/prescriptions/PrescriptionEditor.tsx
@@ -1,0 +1,271 @@
+"use client";
+import { useMemo, useState } from "react";
+import { getActiveOrg } from "@/lib/org-local";
+import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
+import TemplatePicker from "./TemplatePicker";
+
+type Item = {
+  drug: string;
+  dose: string;
+  route: string;
+  freq: string;
+  duration: string;
+  instructions?: string;
+};
+
+type TemplateRef = { id: string };
+
+export default function PrescriptionEditor() {
+  const org = useMemo(() => getActiveOrg(), []);
+  const orgId = org?.id || "";
+  const [patient, setPatient] = useState<{ id: string; label: string } | null>(null);
+  const [items, setItems] = useState<Item[]>([]);
+  const [notes, setNotes] = useState("");
+  const [letterheadPath, setLetterheadPath] = useState<string>("");
+  const [signaturePath, setSignaturePath] = useState<string>("");
+  const [issuedAt, setIssuedAt] = useState<string>(() => new Date().toISOString().slice(0, 16));
+  const [saving, setSaving] = useState(false);
+
+  function addEmpty() {
+    setItems((xs) => [...xs, { drug: "", dose: "", route: "", freq: "", duration: "", instructions: "" }]);
+  }
+
+  function removeAt(i: number) {
+    setItems((xs) => xs.filter((_, idx) => idx !== i));
+  }
+
+  function setAt<T extends keyof Item>(i: number, k: T, v: Item[T]) {
+    setItems((xs) => xs.map((x, idx) => (idx === i ? { ...x, [k]: v } : x)));
+  }
+
+  async function searchDrug(i: number, q: string) {
+    if (q.trim().length < 2) return;
+    const params = new URLSearchParams({ q });
+    const r = await fetch(`/api/catalog/drugs/search?${params.toString()}`, { cache: "no-store" });
+    const j = await r.json();
+    const rows = Array.isArray(j?.data) ? j.data : Array.isArray(j?.items) ? j.items : [];
+    if (rows[0]?.name) {
+      setAt(i, "drug", rows[0].name);
+    }
+  }
+
+  async function save() {
+    if (!orgId || !patient?.id || items.length === 0) {
+      alert("Faltan datos");
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        org_id: orgId,
+        patient_id: patient.id,
+        letterhead_path: letterheadPath || null,
+        signature_path: signaturePath || null,
+        notes: notes || null,
+        issued_at: issuedAt ? new Date(issuedAt).toISOString() : null,
+        items,
+      };
+      const r = await fetch("/api/prescriptions/create", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const j = await r.json();
+      const newId: string | undefined = j?.data?.id ?? j?.id;
+      if (!newId) {
+        alert(j?.error?.message ?? "Error al guardar");
+        return;
+      }
+      window.open(`/print/recetas/${newId}`, "_blank");
+      setItems([]);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function useTemplate(tpl: TemplateRef) {
+    if (!orgId || !patient?.id) {
+      alert("Elige paciente");
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        org_id: orgId,
+        patient_id: patient.id,
+        template_id: tpl.id,
+        letterhead_path: letterheadPath || null,
+        signature_path: signaturePath || null,
+        issued_at: new Date().toISOString(),
+      };
+      const r = await fetch("/api/prescriptions/from-template", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const j = await r.json();
+      const newId: string | undefined = j?.data?.id ?? j?.id;
+      if (!newId) {
+        alert(j?.error?.message ?? "Error al usar plantilla");
+        return;
+      }
+      window.open(`/print/recetas/${newId}`, "_blank");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="border rounded-2xl p-4 space-y-3">
+        <h3 className="font-semibold">Paciente</h3>
+        {!orgId ? (
+          <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
+            Selecciona una organización activa.
+          </p>
+        ) : (
+          <PatientAutocomplete orgId={orgId} scope="mine" onSelect={setPatient} placeholder="Buscar paciente…" />
+        )}
+        {patient && (
+          <div className="text-sm text-slate-600">
+            Paciente: <strong>{patient.label}</strong>
+          </div>
+        )}
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-3">
+        <div className="border rounded-2xl p-4 space-y-2">
+          <h3 className="font-semibold">Membrete/Firma (opcional)</h3>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            placeholder="letterheads/<org>/<file>.png"
+            value={letterheadPath}
+            onChange={(e) => setLetterheadPath(e.target.value)}
+          />
+          <input
+            className="border rounded px-3 py-2 w-full"
+            placeholder="signatures/<org>/<file>.png"
+            value={signaturePath}
+            onChange={(e) => setSignaturePath(e.target.value)}
+          />
+          <label className="text-sm">Fecha/hora emisión</label>
+          <input
+            type="datetime-local"
+            className="border rounded px-3 py-2 w-full"
+            value={issuedAt}
+            onChange={(e) => setIssuedAt(e.target.value)}
+          />
+        </div>
+        <div className="md:col-span-2 border rounded-2xl p-4">
+          <h3 className="font-semibold">Plantillas</h3>
+          {orgId && <TemplatePicker orgId={orgId} onChoose={useTemplate} />}
+        </div>
+      </div>
+
+      <div className="border rounded-2xl p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold">Renglones de receta</h3>
+          <button className="border rounded px-3 py-2" onClick={addEmpty}>
+            Agregar renglón
+          </button>
+        </div>
+        <div className="rounded border overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="text-left px-3 py-2">Fármaco</th>
+                <th className="text-left px-3 py-2">Dosis</th>
+                <th className="text-left px-3 py-2">Vía</th>
+                <th className="text-left px-3 py-2">Frecuencia</th>
+                <th className="text-left px-3 py-2">Duración</th>
+                <th className="text-left px-3 py-2">Indicaciones</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-56"
+                      value={it.drug}
+                      onChange={(e) => setAt(i, "drug", e.target.value)}
+                      onBlur={(e) => searchDrug(i, e.target.value)}
+                      placeholder="Buscar/Escribir fármaco…"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-32"
+                      value={it.dose}
+                      onChange={(e) => setAt(i, "dose", e.target.value)}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-28"
+                      value={it.route}
+                      onChange={(e) => setAt(i, "route", e.target.value)}
+                      placeholder="VO/IM/IV..."
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-32"
+                      value={it.freq}
+                      onChange={(e) => setAt(i, "freq", e.target.value)}
+                      placeholder="cada 8h..."
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-28"
+                      value={it.duration}
+                      onChange={(e) => setAt(i, "duration", e.target.value)}
+                      placeholder="7 días..."
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      className="border rounded px-2 py-1 w-56"
+                      value={it.instructions || ""}
+                      onChange={(e) => setAt(i, "instructions", e.target.value)}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <button className="border rounded px-2 py-1" onClick={() => removeAt(i)}>
+                      Quitar
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {!items.length && (
+                <tr>
+                  <td colSpan={7} className="px-3 py-6 text-center text-slate-500">
+                    Agrega al menos un renglón
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <label className="text-sm">Notas</label>
+          <textarea
+            className="border rounded px-3 py-2 w-full min-h-[100px]"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Instrucciones generales al paciente..."
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <button className="border rounded px-3 py-2" onClick={save} disabled={!patient || items.length === 0 || saving}>
+            Guardar y abrir impresión
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/prescriptions/TemplatePicker.tsx
+++ b/components/prescriptions/TemplatePicker.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Template = { id: string; name: string; active: boolean };
+
+type Props = {
+  orgId: string;
+  mine?: boolean;
+  onChoose: (tpl: Template) => void;
+};
+
+export default function TemplatePicker({ orgId, mine = false, onChoose }: Props) {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    if (!orgId) {
+      setRows([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ org_id: orgId, mine: mine ? "1" : "0" });
+      if (q) params.set("q", q);
+      const r = await fetch(`/api/prescriptions/templates?${params.toString()}`, {
+        cache: "no-store",
+      });
+      const j = await r.json();
+      const data = Array.isArray(j?.data) ? j.data : Array.isArray(j?.items) ? j.items : [];
+      setRows(data);
+    } catch (err) {
+      console.error(err);
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, q, mine]);
+
+  return (
+    <section className="border rounded-2xl p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <input
+          className="border rounded px-3 py-2 flex-1"
+          placeholder="Buscar plantilla..."
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <button className="border rounded px-3 py-2" onClick={load} disabled={loading}>
+          {loading ? "Cargando..." : "Buscar"}
+        </button>
+      </div>
+      <div className="rounded border overflow-auto max-h-72">
+        <table className="w-full text-sm">
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-b">
+                <td className="px-3 py-2">{r.name}</td>
+                <td className="px-3 py-2 w-28 text-right">
+                  <button className="border rounded px-3 py-1" onClick={() => onChoose(r)}>
+                    Usar
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!rows.length && (
+              <tr>
+                <td className="px-3 py-6 text-center text-slate-500">
+                  {loading ? "Cargando..." : "Sin plantillas"}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a prescriptions module page with a rich editor for patients, templates, and printable metadata
- expose client components to browse templates and capture prescription rows before saving or reusing templates
- upgrade prescriptions API routes plus JSON/PDF handlers to support the new workflow while keeping legacy payloads compatible

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf7ed477c832a82042eb87aa68f62