### PR TITLE
Add weekly agenda view with scheduling APIs

### DIFF
--- a/app/(app)/agenda/semana/page.tsx
+++ b/app/(app)/agenda/semana/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import AccentHeader from "@/components/ui/AccentHeader";
+import ProviderSelect from "@/components/agenda/ProviderSelect";
+import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
+import WeekGrid from "@/components/agenda/WeekGrid";
+import { getActiveOrg } from "@/lib/org-local";
+
+export default function AgendaSemanaPage() {
+  const org = useMemo(() => getActiveOrg(), []);
+  const orgId = org?.id || "";
+
+  const [providerId, setProviderId] = useState<string>("");
+  const [patient, setPatient] = useState<{ id: string; label: string } | null>(
+    null
+  );
+  const [tz, setTz] = useState<string>("America/Mexico_City");
+  const [baseDate, setBaseDate] = useState<string>(() => {
+    const d = new Date();
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${dd}`;
+  });
+
+  function shiftDays(n: number) {
+    const t = new Date(`${baseDate}T00:00:00`);
+    const nx = new Date(t.getTime() + n * 86400000);
+    setBaseDate(nx.toISOString().slice(0, 10));
+  }
+
+  return (
+    <main className="p-6 md:p-10 space-y-6">
+      <AccentHeader
+        title="Agenda semanal"
+        subtitle="Visualiza disponibilidad, crea citas rápido y reprograma con chequeo de colisiones."
+        emojiToken="agenda"
+      />
+
+      {!orgId && (
+        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
+          Selecciona una organización activa.
+        </p>
+      )}
+
+      <section className="border rounded-2xl p-4 space-y-3 bg-white/80">
+        <div className="grid md:grid-cols-3 gap-3">
+          <div>
+            <label className="text-sm">Profesional</label>
+            <ProviderSelect value={providerId} onChange={setProviderId} />
+          </div>
+          <div>
+            <label className="text-sm">Paciente</label>
+            {orgId ? (
+              <PatientAutocomplete
+                orgId={orgId}
+                scope="mine"
+                onSelect={setPatient}
+                placeholder="Buscar paciente…"
+              />
+            ) : (
+              <input
+                className="border rounded px-3 py-2 w-full"
+                disabled
+                placeholder="Selecciona una organización"
+              />
+            )}
+            {patient && (
+              <p className="text-xs text-slate-600 mt-1">
+                Elegido: <strong>{patient.label}</strong>
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="text-sm">Zona horaria</label>
+            <input
+              className="border rounded px-3 py-2 w-full"
+              value={tz}
+              onChange={(e) => setTz(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-sm">Semana base</label>
+          <input
+            type="date"
+            className="border rounded px-3 py-2"
+            value={baseDate}
+            onChange={(e) => setBaseDate(e.target.value)}
+          />
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              className="border rounded px-3 py-2"
+              onClick={() => shiftDays(-7)}
+            >
+              ← Anterior
+            </button>
+            <button
+              className="border rounded px-3 py-2"
+              onClick={() => shiftDays(7)}
+            >
+              Siguiente →
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {orgId && providerId ? (
+        <WeekGrid
+          orgId={orgId}
+          providerId={providerId}
+          tz={tz}
+          baseDate={baseDate}
+          patientId={patient?.id || null}
+          defaultDurationMin={30}
+        />
+      ) : (
+        <p className="text-slate-500">
+          Completa profesional y organización para ver la agenda.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/app/api/agenda/appointments/list/route.ts
+++ b/app/api/agenda/appointments/list/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const u = new URL(req.url);
+  const orgId = u.searchParams.get("org_id");
+  const providerId = u.searchParams.get("provider_id");
+  const from = u.searchParams.get("from");
+  const to = u.searchParams.get("to");
+  if (!orgId || !providerId || !from || !to) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "BAD_REQUEST",
+          message: "org_id, provider_id, from y to requeridos",
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supa
+    .from("agenda_appointments")
+    .select("id, patient_id, starts_at, ends_at, tz, location, status, notes")
+    .eq("org_id", orgId)
+    .eq("provider_id", providerId)
+    .gte("starts_at", from)
+    .lte("starts_at", to)
+    .order("starts_at", { ascending: true })
+    .limit(1000);
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: error.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, data: data || [] });
+}

--- a/app/api/agenda/appointments/reschedule/route.ts
+++ b/app/api/agenda/appointments/reschedule/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+function addMinutesIso(iso: string, min: number) {
+  const d = new Date(iso);
+  return new Date(d.getTime() + min * 60_000).toISOString();
+}
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    org_id?: string;
+    id?: string;
+    starts_at?: string;
+    duration_min?: number;
+  };
+  if (!body?.org_id || !body?.id || !body?.starts_at) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "BAD_REQUEST", message: "org_id, id y starts_at requeridos" },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data: oldAppt, error: e0 } = await supa
+    .from("agenda_appointments")
+    .select("id, provider_id, tz, ends_at, starts_at")
+    .eq("org_id", body.org_id)
+    .eq("id", body.id)
+    .single();
+
+  if (e0 || !oldAppt) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Cita no encontrada" } },
+      { status: 404 }
+    );
+  }
+
+  const newStart = new Date(body.starts_at);
+  if (Number.isNaN(newStart.getTime())) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "starts_at inválido" } },
+      { status: 400 }
+    );
+  }
+
+  const durationMin = Math.max(
+    10,
+    Math.min(
+      240,
+      body.duration_min ??
+        Math.round(
+          (new Date(oldAppt.ends_at).getTime() -
+            new Date(oldAppt.starts_at).getTime()) /
+            60000
+        )
+    )
+  );
+  const newEnd = addMinutesIso(newStart.toISOString(), durationMin);
+
+  const { data: coll } = await supa
+    .from("agenda_appointments")
+    .select("id")
+    .eq("org_id", body.org_id)
+    .eq("provider_id", oldAppt.provider_id)
+    .neq("id", body.id)
+    .or(`and(starts_at.lte.${newEnd},ends_at.gte.${newStart.toISOString()})`)
+    .limit(1);
+
+  if (coll && coll.length > 0) {
+    return NextResponse.json(
+      { ok: false, error: { code: "TIME_CONFLICT", message: "Conflicto con otra cita" } },
+      { status: 409 }
+    );
+  }
+
+  const { error: e1 } = await supa
+    .from("agenda_appointments")
+    .update({ starts_at: newStart.toISOString(), ends_at: newEnd })
+    .eq("org_id", body.org_id)
+    .eq("id", body.id);
+
+  if (e1) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e1.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: { id: body.id, starts_at: newStart.toISOString(), ends_at: newEnd },
+  });
+}

--- a/app/api/agenda/availability/week/route.ts
+++ b/app/api/agenda/availability/week/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const { data: au } = await supa.auth.getUser();
+  if (!au?.user) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "No autenticado" } },
+      { status: 401 }
+    );
+  }
+
+  const u = new URL(req.url);
+  const orgId = u.searchParams.get("org_id");
+  const providerId = u.searchParams.get("provider_id");
+  const weekStart =
+    u.searchParams.get("week_start") || new Date().toISOString().slice(0, 10);
+  if (!orgId || !providerId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "BAD_REQUEST",
+          message: "org_id y provider_id requeridos",
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data: av, error: e1 } = await supa
+    .from("agenda_availability")
+    .select("weekday, start_time, end_time, slot_minutes, tz")
+    .eq("org_id", orgId)
+    .eq("provider_id", providerId)
+    .order("weekday", { ascending: true });
+
+  if (e1) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e1.message } },
+      { status: 400 }
+    );
+  }
+
+  const start = new Date(weekStart);
+  if (Number.isNaN(start.getTime())) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BAD_REQUEST", message: "week_start inválido" } },
+      { status: 400 }
+    );
+  }
+  const end = new Date(start.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const { data: ov, error: e2 } = await supa
+    .from("agenda_slots_overrides")
+    .select("date, kind, start_time, end_time")
+    .eq("org_id", orgId)
+    .eq("provider_id", providerId)
+    .gte("date", weekStart)
+    .lte("date", end.toISOString().slice(0, 10))
+    .order("date", { ascending: true });
+
+  if (e2) {
+    return NextResponse.json(
+      { ok: false, error: { code: "DB_ERROR", message: e2.message } },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: { availability: av || [], overrides: ov || [] },
+  });
+}

--- a/components/agenda/ProviderSelect.tsx
+++ b/components/agenda/ProviderSelect.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabaseBrowser } from "@/lib/supabase-browser";
+
+export default function ProviderSelect({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (providerId: string) => void;
+}) {
+  const supa = getSupabaseBrowser();
+  const [me, setMe] = useState<string>("");
+
+  useEffect(() => {
+    supa.auth.getUser().then(({ data }) => {
+      if (data?.user?.id) setMe(data.user.id);
+    });
+  }, [supa]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        className="border rounded px-3 py-2 w-[360px]"
+        placeholder="UUID de profesional"
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="UUID del profesional"
+      />
+      <button
+        type="button"
+        className="border rounded px-3 py-2"
+        onClick={() => me && onChange(me)}
+        title="Usar mi usuario"
+      >
+        Usar mi usuario
+      </button>
+    </div>
+  );
+}

--- a/components/agenda/WeekGrid.tsx
+++ b/components/agenda/WeekGrid.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Appt = {
+  id: string;
+  patient_id: string;
+  starts_at: string;
+  ends_at: string;
+  status: string;
+  location: string | null;
+  notes: string | null;
+};
+type Avail = {
+  weekday: number;
+  start_time: string;
+  end_time: string;
+  slot_minutes: number;
+  tz: string;
+};
+type Override = {
+  date: string;
+  kind: "block" | "extra";
+  start_time: string;
+  end_time: string;
+};
+
+function dayKey(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+function addDays(d: Date, n: number) {
+  return new Date(d.getTime() + n * 86400000);
+}
+function toLocalHm(date: Date) {
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export default function WeekGrid({
+  orgId,
+  providerId,
+  tz,
+  baseDate,
+  patientId,
+  defaultDurationMin = 30,
+}: {
+  orgId: string;
+  providerId: string;
+  tz: string;
+  baseDate: string;
+  patientId?: string | null;
+  defaultDurationMin?: number;
+}) {
+  const weekStart = useMemo(() => new Date(`${baseDate}T00:00:00`), [baseDate]);
+  const weekDays = useMemo(
+    () => [...Array(7)].map((_, i) => addDays(weekStart, i)),
+    [weekStart]
+  );
+
+  const [availability, setAvailability] = useState<Avail[]>([]);
+  const [overrides, setOverrides] = useState<Override[]>([]);
+  const [appts, setAppts] = useState<Appt[]>([]);
+  const [hoursStart, setHoursStart] = useState(8);
+  const [hoursEnd, setHoursEnd] = useState(20);
+  const [busy, setBusy] = useState(false);
+  const [resched, setResched] = useState<{
+    id: string;
+    newStart: string;
+    duration: number;
+  } | null>(null);
+
+  const fromIso = useMemo(() => new Date(weekStart).toISOString(), [weekStart]);
+  const toIso = useMemo(
+    () => new Date(addDays(weekStart, 7)).toISOString(),
+    [weekStart]
+  );
+
+  async function loadAll() {
+    if (!orgId || !providerId) return;
+    setBusy(true);
+    const qs1 = new URLSearchParams({
+      org_id: orgId,
+      provider_id: providerId,
+      week_start: baseDate,
+    });
+    const qs2 = new URLSearchParams({
+      org_id: orgId,
+      provider_id: providerId,
+      from: fromIso,
+      to: toIso,
+    });
+    const [a, b] = await Promise.all([
+      fetch(`/api/agenda/availability/week?${qs1.toString()}`, {
+        cache: "no-store",
+      }).then((r) => r.json()),
+      fetch(`/api/agenda/appointments/list?${qs2.toString()}`, {
+        cache: "no-store",
+      }).then((r) => r.json()),
+    ]);
+    setAvailability(a?.ok ? a.data.availability : []);
+    setOverrides(a?.ok ? a.data.overrides : []);
+    setAppts(b?.ok ? b.data : []);
+    setBusy(false);
+  }
+
+  useEffect(() => {
+    loadAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, providerId, baseDate, tz]);
+
+  function isWithinAvailability(d: Date) {
+    const wd = d.getDay() === 0 ? 7 : d.getDay();
+    const hm = d.toTimeString().slice(0, 5);
+    const day = dayKey(d);
+    const avs = availability.filter((a) => a.weekday === wd);
+    if (avs.length === 0) return false;
+    const base = avs.some((a) => `${hm}` >= a.start_time && `${hm}` < a.end_time);
+    const extras = overrides.filter((o) => o.date === day && o.kind === "extra");
+    if (extras.length > 0) {
+      return extras.some((x) => hm >= x.start_time && hm < x.end_time);
+    }
+    const blocks = overrides.filter((o) => o.date === day && o.kind === "block");
+    if (blocks.some((x) => hm >= x.start_time && hm < x.end_time)) return false;
+    return base;
+  }
+
+  function apptAt(d: Date) {
+    const iso = d.toISOString();
+    return appts.find((a) => !(a.ends_at <= iso || iso < a.starts_at));
+  }
+
+  async function createAt(d: Date) {
+    if (!patientId) {
+      alert("Selecciona paciente antes de crear una cita.");
+      return;
+    }
+    if (!isWithinAvailability(d)) {
+      alert("Fuera de disponibilidad/override.");
+      return;
+    }
+    const payload = {
+      org_id: orgId,
+      provider_id: providerId,
+      patient_id: patientId,
+      starts_at: d.toISOString(),
+      duration_min: defaultDurationMin,
+      tz,
+      schedule_reminders: true,
+    };
+    const r = await fetch("/api/agenda/appointments/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const j = await r.json();
+    if (!j.ok) {
+      alert(j.error?.message ?? "Error al crear cita");
+      return;
+    }
+    await loadAll();
+  }
+
+  async function markStatus(id: string, status: "completed" | "no_show" | "cancelled") {
+    const r = await fetch("/api/agenda/appointments/update-status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ org_id: orgId, ids: [id], status }),
+    });
+    const j = await r.json();
+    if (!j.ok) {
+      alert(j.error?.message ?? "Error al actualizar");
+      return;
+    }
+    await loadAll();
+  }
+
+  async function doReschedule() {
+    if (!resched) return;
+    const r = await fetch("/api/agenda/appointments/reschedule", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        org_id: orgId,
+        id: resched.id,
+        starts_at: resched.newStart,
+        duration_min: resched.duration,
+      }),
+    });
+    const j = await r.json();
+    if (!j.ok) {
+      alert(j.error?.message ?? "No se pudo reprogramar");
+      return;
+    }
+    setResched(null);
+    await loadAll();
+  }
+
+  const hours = useMemo(() => {
+    const arr: string[] = [];
+    for (let h = hoursStart; h <= hoursEnd; h += 1) {
+      arr.push(String(h).padStart(2, "0") + ":00");
+      arr.push(String(h).padStart(2, "0") + ":30");
+    }
+    return arr;
+  }, [hoursStart, hoursEnd]);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <span className="px-2 py-1 rounded border bg-white">
+          Semana: {dayKey(weekDays[0])} → {dayKey(weekDays[6])}
+        </span>
+        <span className="px-2 py-1 rounded border bg-white">
+          {busy ? "Cargando…" : "Listo"}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <label>Horario:</label>
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-16"
+            min={0}
+            max={23}
+            value={hoursStart}
+            onChange={(e) => setHoursStart(Number(e.target.value || 8))}
+          />
+          <span>—</span>
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-16"
+            min={0}
+            max={23}
+            value={hoursEnd}
+            onChange={(e) => setHoursEnd(Number(e.target.value || 20))}
+          />
+          <button className="border rounded px-3 py-1" onClick={loadAll}>
+            Actualizar
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-8 border rounded-2xl overflow-hidden">
+        <div className="bg-slate-50 p-2 text-sm font-medium">Hora</div>
+        {weekDays.map((d, i) => (
+          <div key={i} className="bg-slate-50 p-2 text-sm font-medium">
+            {d.toLocaleDateString(undefined, {
+              weekday: "short",
+              day: "2-digit",
+              month: "short",
+            })}
+          </div>
+        ))}
+
+        {hours.map((hm, rIdx) => (
+          <FragmentRow
+            key={rIdx}
+            hm={hm}
+            weekDays={weekDays}
+            appts={appts}
+            isWithinAvailability={isWithinAvailability}
+            apptAt={apptAt}
+            onCreate={createAt}
+            onStatus={markStatus}
+            onPlanReschedule={(id, newStartIso, dur) =>
+              setResched({ id, newStart: newStartIso, duration: dur })
+            }
+          />
+        ))}
+      </div>
+
+      {resched && (
+        <div className="p-3 border rounded-xl bg-white flex items-center gap-3">
+          <span className="font-medium">Reprogramar</span>
+          <input
+            type="datetime-local"
+            className="border rounded px-3 py-2"
+            value={resched.newStart.slice(0, 16)}
+            onChange={(e) =>
+              setResched({
+                ...resched,
+                newStart: new Date(e.target.value).toISOString(),
+              })
+            }
+          />
+          <input
+            type="number"
+            min={10}
+            max={240}
+            className="border rounded px-3 py-2 w-24"
+            value={resched.duration}
+            onChange={(e) =>
+              setResched({
+                ...resched,
+                duration: Number(e.target.value || 30),
+              })
+            }
+          />
+          <button className="border rounded px-3 py-2" onClick={doReschedule}>
+            Guardar
+          </button>
+          <button
+            className="border rounded px-3 py-2"
+            onClick={() => setResched(null)}
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function FragmentRow({
+  hm,
+  weekDays,
+  appts,
+  isWithinAvailability,
+  apptAt,
+  onCreate,
+  onStatus,
+  onPlanReschedule,
+}: {
+  hm: string;
+  weekDays: Date[];
+  appts: Appt[];
+  isWithinAvailability: (d: Date) => boolean;
+  apptAt: (d: Date) => Appt | undefined;
+  onCreate: (d: Date) => Promise<void>;
+  onStatus: (
+    id: string,
+    st: "completed" | "no_show" | "cancelled"
+  ) => Promise<void>;
+  onPlanReschedule: (id: string, newStartIso: string, dur: number) => void;
+}) {
+  return (
+    <>
+      <div className="p-2 border-t text-xs text-slate-500">{hm}</div>
+      {weekDays.map((d, cIdx) => {
+        const dt = new Date(`${d.toISOString().slice(0, 10)}T${hm}:00`);
+        const ap = apptAt(dt);
+        const allowed = isWithinAvailability(dt);
+        if (ap) {
+          const dur = Math.max(
+            10,
+            Math.round(
+              (new Date(ap.ends_at).getTime() -
+                new Date(ap.starts_at).getTime()) /
+                60000
+            )
+          );
+          return (
+            <div key={cIdx} className="border-t p-1">
+              <div className="rounded-lg border px-2 py-1 bg-sky-50 text-sky-900 text-xs flex items-center justify-between">
+                <div className="truncate">
+                  {toLocalHm(new Date(ap.starts_at))} • {dur} min • {ap.status}
+                </div>
+                <div className="flex items-center gap-1 ml-2">
+                  <button
+                    className="px-2 py-0.5 rounded border"
+                    onClick={() => onStatus(ap.id, "completed")}
+                  >
+                    ✔
+                  </button>
+                  <button
+                    className="px-2 py-0.5 rounded border"
+                    onClick={() => onStatus(ap.id, "no_show")}
+                  >
+                    ⛔
+                  </button>
+                  <button
+                    className="px-2 py-0.5 rounded border"
+                    onClick={() => {
+                      const iso = new Date(ap.starts_at).toISOString();
+                      onPlanReschedule(ap.id, iso, dur);
+                    }}
+                  >
+                    ↻
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        }
+        return (
+          <button
+            key={cIdx}
+            className={[
+              "border-t h-10 w-full text-xs",
+              allowed
+                ? "hover:bg-emerald-50"
+                : "bg-slate-50 text-slate-400 cursor-not-allowed",
+            ].join(" ")}
+            onClick={() => allowed && onCreate(dt)}
+            disabled={!allowed}
+            title={allowed ? "Crear cita aquí" : "Fuera de disponibilidad"}
+            aria-label={allowed ? "Crear cita" : "No disponible"}
+          />
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add authenticated API routes to serve weekly availability, list appointments, and reschedule visits
- build agenda provider selector and interactive week grid components for scheduling and status updates
- expose a weekly agenda page that wires organization, provider, and patient selection to the grid

## Testing
- pnpm lint *(fails: missing @eslint/js dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9f5fc84832a9c4d7a840e9e4d69