### PR TITLE
Refactor clinical APIs to new response helpers

### DIFF
--- a/app/api/discharges/[id]/json/route.ts
+++ b/app/api/discharges/[id]/json/route.ts
@@ -1,40 +1,91 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, badRequest, notFound, dbError, serverError } from "@/lib/api/responses";
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const id = params.id;
-  const { data: dis } = await supabase.from("discharges").select("*").eq("id", id).maybeSingle();
-  if (!dis) return NextResponse.json({ error: "No encontrada" }, { status: 404 });
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
 
-  const { data: patient } = await supabase
-    .from("patients")
-    .select("full_name, external_id")
-    .eq("id", dis.patient_id)
-    .maybeSingle();
-  const { data: letterhead } = await supabase
-    .from("doctor_letterheads")
-    .select("*")
-    .eq("org_id", dis.org_id)
-    .eq("doctor_id", dis.doctor_id)
-    .maybeSingle();
-  const { data: d } = await supabase
-    .from("org_disclaimers")
-    .select("text")
-    .eq("org_id", dis.org_id)
-    .eq("kind", "discharge")
-    .maybeSingle();
-  const { data: ledger } = await supabase.rpc("ensure_document_folio", {
-    p_doc_type: "discharge",
-    p_doc_id: id,
-  });
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  return NextResponse.json({
-    discharge: dis,
-    patient,
-    letterhead,
-    footer: letterhead?.footer_disclaimer || d?.text || "",
-    ledger,
-  });
+    const orgId = new URL(req.url).searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
+
+    const { data: discharge, error: dischargeError } = await supa
+      .from("discharges")
+      .select("*")
+      .eq("id", params.id)
+      .eq("org_id", orgId)
+      .maybeSingle();
+
+    if (dischargeError) {
+      return dbError(dischargeError);
+    }
+
+    if (!discharge) {
+      return notFound("Alta no encontrada");
+    }
+
+    const [{ data: patient, error: patientError }, { data: letterhead, error: letterheadError }] = await Promise.all([
+      supa
+        .from("patients")
+        .select("full_name, external_id")
+        .eq("id", discharge.patient_id)
+        .maybeSingle(),
+      supa
+        .from("doctor_letterheads")
+        .select("*")
+        .eq("org_id", discharge.org_id)
+        .eq("doctor_id", discharge.doctor_id)
+        .maybeSingle(),
+    ]);
+
+    if (patientError) {
+      return dbError(patientError);
+    }
+
+    if (letterheadError) {
+      return dbError(letterheadError);
+    }
+
+    let footer = letterhead?.footer_disclaimer || "";
+    if (!footer) {
+      const { data: disclaimer, error: disclaimerError } = await supa
+        .from("org_disclaimers")
+        .select("text")
+        .eq("org_id", discharge.org_id)
+        .eq("kind", "discharge")
+        .maybeSingle();
+
+      if (disclaimerError) {
+        return dbError(disclaimerError);
+      }
+
+      footer = disclaimer?.text || footer;
+    }
+
+    const { data: ledger, error: ledgerError } = await supa.rpc("ensure_document_folio", {
+      p_doc_type: "discharge",
+      p_doc_id: params.id,
+    });
+
+    if (ledgerError) {
+      return dbError(ledgerError);
+    }
+
+    return ok({
+      discharge,
+      patient,
+      letterhead,
+      footer,
+      ledger,
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
 }

--- a/app/api/discharges/[id]/pdf/route.ts
+++ b/app/api/discharges/[id]/pdf/route.ts
@@ -1,136 +1,201 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { badRequest, unauthorized, notFound, dbError, serverError } from "@/lib/api/responses";
 import { newPdf, pngFromDataUrl, makeQrDataUrl, drawWrappedText } from "@/lib/pdf";
 
 async function signedBuf(supabase: any, bucket: string, key: string) {
   const k = key.replace(new RegExp(`^${bucket}/`), "");
-  const { data } = await supabase.storage.from(bucket).createSignedUrl(k, 60);
+  const { data, error } = await supabase.storage.from(bucket).createSignedUrl(k, 60);
+  if (error) throw error;
   if (!data?.signedUrl) return null;
   const r = await fetch(data.signedUrl);
   if (!r.ok) return null;
   return await r.arrayBuffer();
 }
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const id = params.id;
-  const { data: dis } = await supabase.from("discharges").select("*").eq("id", id).maybeSingle();
-  if (!dis) return NextResponse.json({ error: "No encontrada" }, { status: 404 });
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await getSupabaseServer();
 
-  const { data: pat } = await supabase
-    .from("patients")
-    .select("full_name, external_id")
-    .eq("id", dis.patient_id)
-    .maybeSingle();
-  const { data: lh } = await supabase
-    .from("doctor_letterheads")
-    .select("*")
-    .eq("org_id", dis.org_id)
-    .eq("doctor_id", dis.doctor_id)
-    .maybeSingle();
-  let footer = lh?.footer_disclaimer || "";
-  if (!footer) {
-    const { data: d } = await supabase
-      .from("org_disclaimers")
-      .select("text")
-      .eq("org_id", dis.org_id)
-      .eq("kind", "discharge")
+  try {
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
+
+    const orgId = new URL(req.url).searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
+
+    const { data: discharge, error: dischargeError } = await supabase
+      .from("discharges")
+      .select("*")
+      .eq("id", params.id)
+      .eq("org_id", orgId)
       .maybeSingle();
-    footer = d?.text || footer;
-  }
 
-  const { data: led } = await supabase.rpc("ensure_document_folio", {
-    p_doc_type: "discharge",
-    p_doc_id: id,
-  });
-  const verifyUrl = `${process.env.NEXT_PUBLIC_APP_URL || ""}/api/docs/verify?type=discharge&id=${id}&code=${led.verify_code}`;
-  const qrDataUrl = await makeQrDataUrl(verifyUrl);
-
-  const { pdf, page, bold, W, H } = await newPdf();
-  let y = H - 40;
-
-  if (lh?.logo_url) {
-    const ab = await signedBuf(supabase, "letterheads", lh.logo_url);
-    if (ab) {
-      const img = await pdf.embedPng(ab);
-      const w = 120,
-        h = (img.height / img.width) * w;
-      page.drawImage(img, { x: 40, y: y - h + 8, width: w, height: h });
+    if (dischargeError) {
+      return dbError(dischargeError);
     }
-  }
-  page.setFont(bold);
-  page.drawText(lh?.display_name || "Médico/a", { x: 180, y, size: 14 });
-  y -= 16;
-  if (lh?.credentials) {
-    page.drawText(lh.credentials, { x: 180, y, size: 10 });
-    y -= 12;
-  }
-  if (lh?.clinic_info) {
-    page.drawText(lh.clinic_info, { x: 180, y, size: 10 });
-    y -= 12;
-  }
-  page.drawText(`Folio: ${led.folio}`, { x: W - 160, y: H - 40, size: 10 });
-  page.drawText(new Date(dis.created_at).toLocaleString(), { x: W - 160, y: H - 54, size: 10 });
 
-  y -= 8;
-  page.drawText("Resumen de alta", { x: 40, y, size: 12 });
-  y -= 14;
-  page.drawText(`Paciente: ${pat?.full_name || dis.patient_id}`, { x: 40, y, size: 10 });
-  y -= 12;
-  if (dis.admission_at) {
-    page.drawText(`Ingreso: ${new Date(dis.admission_at).toLocaleString()}`, {
-      x: 40,
-      y,
-      size: 10,
-    });
-    y -= 12;
-  }
-  if (dis.discharge_at) {
-    page.drawText(`Alta: ${new Date(dis.discharge_at).toLocaleString()}`, { x: 40, y, size: 10 });
-    y -= 12;
-  }
-  if (dis.diagnosis) {
-    y = drawWrappedText(page, `Diagnóstico: ${dis.diagnosis}`, 40, y - 6, W - 80, 10);
-  }
-  if (dis.summary) {
-    y = drawWrappedText(page, `Resumen: ${dis.summary}`, 40, y - 6, W - 80, 10);
-  }
-  if (dis.recommendations) {
-    y = drawWrappedText(page, `Recomendaciones: ${dis.recommendations}`, 40, y - 6, W - 80, 10);
-  }
-  if (dis.follow_up_at) {
-    page.drawText(`Seguimiento: ${new Date(dis.follow_up_at).toLocaleString()}`, {
-      x: 40,
-      y: y - 6,
-      size: 10,
-    });
-    y -= 18;
-  }
-
-  if (lh?.signature_url) {
-    const ab = await signedBuf(supabase, "signatures", lh.signature_url);
-    if (ab) {
-      const img = await pdf.embedPng(ab);
-      const w = 140,
-        h = (img.height / img.width) * w;
-      page.drawImage(img, { x: W - 40 - w, y: 90, width: w, height: h });
+    if (!discharge) {
+      return notFound("Alta no encontrada");
     }
-  }
-  const qr = await pngFromDataUrl(pdf, qrDataUrl);
-  page.drawImage(qr, { x: W - 160, y: 40, width: 100, height: 100 });
-  page.drawText("Verificar:", { x: W - 160, y: 144, size: 9 });
-  page.drawText(verifyUrl.slice(0, 46), { x: W - 160, y: 132, size: 8 });
-  if (verifyUrl.length > 46)
-    page.drawText(verifyUrl.slice(46, 92), { x: W - 160, y: 122, size: 8 });
-  if (footer) page.drawText(footer.slice(0, 300), { x: 40, y: 60, size: 9 });
 
-  const bytes = await pdf.save();
-  return new NextResponse(bytes, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `attachment; filename="discharge_${dis.id}.pdf"`,
-    },
-  });
+    const [{ data: patient, error: patientError }, { data: letterhead, error: letterheadError }] = await Promise.all([
+      supabase
+        .from("patients")
+        .select("full_name, external_id")
+        .eq("id", discharge.patient_id)
+        .maybeSingle(),
+      supabase
+        .from("doctor_letterheads")
+        .select("*")
+        .eq("org_id", discharge.org_id)
+        .eq("doctor_id", discharge.doctor_id)
+        .maybeSingle(),
+    ]);
+
+    if (patientError) {
+      return dbError(patientError);
+    }
+
+    if (letterheadError) {
+      return dbError(letterheadError);
+    }
+
+    let footer = letterhead?.footer_disclaimer || "";
+    if (!footer) {
+      const { data: disclaimer, error: disclaimerError } = await supabase
+        .from("org_disclaimers")
+        .select("text")
+        .eq("org_id", discharge.org_id)
+        .eq("kind", "discharge")
+        .maybeSingle();
+
+      if (disclaimerError) {
+        return dbError(disclaimerError);
+      }
+
+      footer = disclaimer?.text || footer;
+    }
+
+    const { data: ledger, error: ledgerError } = await supabase.rpc("ensure_document_folio", {
+      p_doc_type: "discharge",
+      p_doc_id: params.id,
+    });
+
+    if (ledgerError) {
+      return dbError(ledgerError);
+    }
+
+    const verifyUrl = `${process.env.NEXT_PUBLIC_APP_URL || ""}/api/docs/verify?type=discharge&id=${params.id}&code=${
+      ledger?.verify_code
+    }`;
+    const qrDataUrl = await makeQrDataUrl(verifyUrl);
+
+    const { pdf, page, bold, W, H } = await newPdf();
+    let y = H - 40;
+
+    if (letterhead?.logo_url) {
+      try {
+        const ab = await signedBuf(supabase, "letterheads", letterhead.logo_url);
+        if (ab) {
+          const img = await pdf.embedPng(ab);
+          const w = 120;
+          const h = (img.height / img.width) * w;
+          page.drawImage(img, { x: 40, y: y - h + 8, width: w, height: h });
+        }
+      } catch {
+        // Ignorar errores de logo
+      }
+    }
+
+    page.setFont(bold);
+    page.drawText(letterhead?.display_name || "Médico/a", { x: 180, y, size: 14 });
+    y -= 16;
+    if (letterhead?.credentials) {
+      page.drawText(letterhead.credentials, { x: 180, y, size: 10 });
+      y -= 12;
+    }
+    if (letterhead?.clinic_info) {
+      page.drawText(letterhead.clinic_info, { x: 180, y, size: 10 });
+      y -= 12;
+    }
+    if (ledger?.folio) {
+      page.drawText(`Folio: ${ledger.folio}`, { x: W - 160, y: H - 40, size: 10 });
+    }
+    page.drawText(new Date(discharge.created_at).toLocaleString(), { x: W - 160, y: H - 54, size: 10 });
+
+    y -= 8;
+    page.drawText("Resumen de alta", { x: 40, y, size: 12 });
+    y -= 14;
+    page.drawText(`Paciente: ${patient?.full_name || discharge.patient_id}`, { x: 40, y, size: 10 });
+    y -= 12;
+    if (discharge.admission_at) {
+      page.drawText(`Ingreso: ${new Date(discharge.admission_at).toLocaleString()}`, { x: 40, y, size: 10 });
+      y -= 12;
+    }
+    if (discharge.discharge_at) {
+      page.drawText(`Alta: ${new Date(discharge.discharge_at).toLocaleString()}`, { x: 40, y, size: 10 });
+      y -= 12;
+    }
+    if (discharge.diagnosis) {
+      y = drawWrappedText(page, `Diagnóstico: ${discharge.diagnosis}`, 40, y - 6, W - 80, 10);
+    }
+    if (discharge.summary) {
+      y = drawWrappedText(page, `Resumen: ${discharge.summary}`, 40, y - 6, W - 80, 10);
+    }
+    if (discharge.recommendations) {
+      y = drawWrappedText(page, `Recomendaciones: ${discharge.recommendations}`, 40, y - 6, W - 80, 10);
+    }
+    if (discharge.follow_up_at) {
+      page.drawText(`Seguimiento: ${new Date(discharge.follow_up_at).toLocaleString()}`, {
+        x: 40,
+        y: y - 6,
+        size: 10,
+      });
+      y -= 18;
+    }
+
+    if (letterhead?.signature_url) {
+      try {
+        const ab = await signedBuf(supabase, "signatures", letterhead.signature_url);
+        if (ab) {
+          const img = await pdf.embedPng(ab);
+          const w = 140;
+          const h = (img.height / img.width) * w;
+          page.drawImage(img, { x: W - 40 - w, y: 90, width: w, height: h });
+        }
+      } catch {
+        // Ignorar errores de firma
+      }
+    }
+
+    if (qrDataUrl) {
+      const qr = await pngFromDataUrl(pdf, qrDataUrl);
+      page.drawImage(qr, { x: W - 160, y: 40, width: 100, height: 100 });
+      page.drawText("Verificar:", { x: W - 160, y: 144, size: 9 });
+      page.drawText(verifyUrl.slice(0, 46), { x: W - 160, y: 132, size: 8 });
+      if (verifyUrl.length > 46) {
+        page.drawText(verifyUrl.slice(46, 92), { x: W - 160, y: 122, size: 8 });
+      }
+    }
+
+    if (footer) {
+      page.drawText(footer.slice(0, 300), { x: 40, y: 60, size: 9 });
+    }
+
+    const bytes = await pdf.save();
+    return new NextResponse(bytes, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="discharge_${discharge.id}.pdf"`,
+        "Cache-Control": "private, max-age=0",
+      },
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error generando PDF");
+  }
 }

--- a/app/api/discharges/route.ts
+++ b/app/api/discharges/route.ts
@@ -1,53 +1,103 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, badRequest, forbidden, dbError, serverError } from "@/lib/api/responses";
+import { userBelongsToOrg } from "@/lib/api/orgs";
 
-export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "No auth" }, { status: 401 });
+const createSchema = z.object({
+  org_id: z.string().min(1, "org_id requerido"),
+  name: z.string().min(1, "name requerido"),
+  body: z.record(z.any()).default({}),
+  doctor_scope: z.boolean().optional(),
+});
 
-  const { data: mem } = await supabase
-    .from("organization_members")
-    .select("org_id")
-    .eq("user_id", user.id)
-    .maybeSingle();
-  const org_id = mem?.org_id;
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  const { data } = await supabase
-    .from("discharge_templates")
-    .select("*")
-    .eq("org_id", org_id)
-    .or(`doctor_id.is.null,doctor_id.eq.${user.id}`)
-    .order("doctor_id", { ascending: false });
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  return NextResponse.json({ items: data || [] });
+    const url = new URL(req.url);
+    const orgId = url.searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
+
+    const page = Math.max(1, Number(url.searchParams.get("page") || 1));
+    const pageSize = Math.min(100, Math.max(1, Number(url.searchParams.get("page_size") || 20)));
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    const allowed = await userBelongsToOrg(supa, orgId, auth.user.id);
+    if (!allowed) {
+      return forbidden("Sin acceso a la organización");
+    }
+
+    const { data, error, count } = await supa
+      .from("discharge_templates")
+      .select("*", { count: "exact" })
+      .eq("org_id", orgId)
+      .or(`doctor_id.is.null,doctor_id.eq.${auth.user.id}`)
+      .order("doctor_id", { ascending: false })
+      .range(from, to);
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({
+      items: data ?? [],
+      meta: { page, pageSize, total: count ?? 0 },
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
 }
 
-export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "No auth" }, { status: 401 });
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  const body = await req.json().catch(() => null);
-  const { name, body: b = {}, doctor_scope = true } = body || {};
-  const { data: mem } = await supabase
-    .from("organization_members")
-    .select("org_id")
-    .eq("user_id", user.id)
-    .maybeSingle();
-  const org_id = mem?.org_id;
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const payload = { org_id, doctor_id: doctor_scope ? user.id : null, name, body: b };
-  const { data, error } = await supabase
-    .from("discharge_templates")
-    .insert(payload)
-    .select("*")
-    .single();
-  if (error) return NextResponse.json({ error: "create_failed" }, { status: 500 });
-  return NextResponse.json({ item: data });
+    const json = await req.json().catch(() => null);
+    const parsed = createSchema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
+
+    const body = parsed.data;
+    const allowed = await userBelongsToOrg(supa, body.org_id, auth.user.id);
+    if (!allowed) {
+      return forbidden("Sin acceso a la organización");
+    }
+
+    const doctorScope = body.doctor_scope ?? true;
+    const payload = {
+      org_id: body.org_id,
+      doctor_id: doctorScope ? auth.user.id : null,
+      name: body.name,
+      body: body.body,
+    };
+
+    const { data, error } = await supa
+      .from("discharge_templates")
+      .insert(payload)
+      .select("*")
+      .single();
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({ item: data });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
 }

--- a/app/api/lab/requests/create/route.ts
+++ b/app/api/lab/requests/create/route.ts
@@ -1,111 +1,134 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
 import { randomUUID } from "node:crypto";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, dbError, serverError, error as jsonError, badRequest } from "@/lib/api/responses";
 import { renderTransactionalEmail, toTextFallback } from "@/lib/mail/templates";
+
+const payloadSchema = z.object({
+  org_id: z.string().min(1, "org_id requerido"),
+  patient_id: z.string().min(1, "patient_id requerido"),
+  email: z.string().email("email inválido"),
+  title: z.string().min(1, "title requerido"),
+  instructions: z.string().optional().nullable(),
+  items: z
+    .array(
+      z.object({
+        code: z.string().optional().nullable(),
+        name: z.string().min(1, "name requerido"),
+        notes: z.string().optional().nullable(),
+      }),
+    )
+    .optional(),
+  due_at: z.string().optional().nullable(),
+  token_hours: z.coerce.number().int().min(1).max(24 * 14).optional(),
+});
 
 function addHours(h: number) {
   return new Date(Date.now() + h * 3600 * 1000).toISOString();
 }
 
-export async function POST(req: Request) {
-  const supa = createRouteHandlerClient({ cookies });
-  const body = await req.json().catch(() => ({}));
-  const {
-    org_id,
-    patient_id,
-    email,
-    title,
-    instructions,
-    items = [],
-    due_at = null,
-    token_hours = 72,
-  } = body;
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  if (!org_id || !patient_id || !email || !title)
-    return NextResponse.json(
-      { error: "org_id, patient_id, email, title requeridos" },
-      { status: 400 },
-    );
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    const json = await req.json().catch(() => null);
+    const parsed = payloadSchema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
 
-  // 1) Insert request
-  const { data: reqRow, error: e1 } = await supa
-    .from("lab_requests")
-    .insert({
-      org_id,
-      patient_id,
-      requested_by: auth.user.id,
-      title,
-      instructions,
-      status: "awaiting_upload",
-      due_at,
-    })
-    .select("id")
-    .single();
-  if (e1) return NextResponse.json({ error: e1.message }, { status: 400 });
+    const { org_id, patient_id, email, title, instructions, items = [], due_at = null, token_hours = 72 } = parsed.data;
 
-  // 2) Items (opcionales)
-  if (Array.isArray(items) && items.length) {
-    const payload = items.map((t: any) => ({
-      request_id: reqRow!.id,
-      test_code: t.code || null,
-      test_name: t.name,
-      notes: t.notes || null,
-    }));
-    const { error: e2 } = await supa.from("lab_request_items").insert(payload);
-    if (e2) return NextResponse.json({ error: e2.message }, { status: 400 });
+    const { data: requestRow, error: insertError } = await supa
+      .from("lab_requests")
+      .insert({
+        org_id,
+        patient_id,
+        requested_by: auth.user.id,
+        title,
+        instructions,
+        status: "awaiting_upload",
+        due_at,
+      })
+      .select("id")
+      .single();
+
+    if (insertError) {
+      return dbError(insertError);
+    }
+
+    if (items.length) {
+      const payload = items.map((item) => ({
+        request_id: requestRow!.id,
+        test_code: item.code || null,
+        test_name: item.name,
+        notes: item.notes || null,
+      }));
+
+      const { error: itemsError } = await supa.from("lab_request_items").insert(payload);
+      if (itemsError) {
+        return dbError(itemsError);
+      }
+    }
+
+    const token = randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+    const expires_at = addHours(token_hours);
+
+    const { error: tokenError } = await supa
+      .from("lab_upload_tokens")
+      .insert({ request_id: requestRow!.id, token, expires_at });
+
+    if (tokenError) {
+      return dbError(tokenError);
+    }
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const link = `${appUrl}/portal/lab/upload?token=${encodeURIComponent(token)}`;
+
+    const titleMail = "Solicitud de estudio de laboratorio";
+    const html = renderTransactionalEmail({
+      title: titleMail,
+      intro: "Te compartimos el enlace para subir tu resultado:",
+      highlight: title + (instructions ? ` — ${instructions}` : ""),
+      actionLabel: "Subir estudio",
+      actionUrl: link,
+      footerNote: `Este enlace expira el ${new Date(expires_at).toLocaleString()}.`,
+      previewText: `${title} · Sube tu estudio`,
+    });
+
+    const text = toTextFallback({
+      title: titleMail,
+      intro: "Enlace para subir tu resultado",
+      highlight: title + (instructions ? ` — ${instructions}` : ""),
+      actionLabel: "Subir estudio",
+      actionUrl: link,
+      footerNote: `Expira: ${new Date(expires_at).toLocaleString()}`,
+    });
+
+    const res = await fetch(`${appUrl}/api/mail/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to: email,
+        subject: "Solicitud de laboratorio — Sanoa",
+        html,
+        text,
+      }),
+    });
+
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      return jsonError("MAIL_ERROR", payload.error || "No se pudo enviar el correo", res.status || 400);
+    }
+
+    return ok({ request_id: requestRow!.id, link, expires_at });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
-
-  // 3) Token
-  const token = randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
-  const expires_at = addHours(Math.max(1, Number(token_hours)));
-  const { error: e3 } = await supa
-    .from("lab_upload_tokens")
-    .insert({ request_id: reqRow!.id, token, expires_at });
-  if (e3) return NextResponse.json({ error: e3.message }, { status: 400 });
-
-  // 4) Email (Resend principal, SendGrid fallback vía /api/mail/send)
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-  const link = `${appUrl}/portal/lab/upload?token=${encodeURIComponent(token)}`;
-
-  const titleMail = "Solicitud de estudio de laboratorio";
-  const html = renderTransactionalEmail({
-    title: titleMail,
-    intro: "Te compartimos el enlace para subir tu resultado:",
-    highlight: title + (instructions ? ` — ${instructions}` : ""),
-    actionLabel: "Subir estudio",
-    actionUrl: link,
-    footerNote: `Este enlace expira el ${new Date(expires_at).toLocaleString()}.`,
-    previewText: `${title} · Sube tu estudio`,
-  });
-
-  const text = toTextFallback({
-    title: titleMail,
-    intro: "Enlace para subir tu resultado",
-    highlight: title + (instructions ? ` — ${instructions}` : ""),
-    actionLabel: "Subir estudio",
-    actionUrl: link,
-    footerNote: `Expira: ${new Date(expires_at).toLocaleString()}`,
-  });
-
-  const res = await fetch(`${appUrl}/api/mail/send`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      to: email,
-      subject: "Solicitud de laboratorio — Sanoa",
-      html,
-      text,
-    }),
-  });
-
-  if (!res.ok) {
-    const j = await res.json().catch(() => ({}));
-    return NextResponse.json({ error: j.error || "No se pudo enviar el correo" }, { status: 400 });
-  }
-
-  return NextResponse.json({ ok: true, request_id: reqRow!.id, link, expires_at });
 }

--- a/app/api/lab/requests/list/route.ts
+++ b/app/api/lab/requests/list/route.ts
@@ -1,57 +1,62 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { ok, badRequest, unauthorized, dbError, serverError } from "@/lib/api/responses";
+import { getSupabaseServer } from "@/lib/supabase/server";
 
-/**
- * GET /api/lab/requests/list?org_id=UUID[&patient_id=UUID][&status=uploaded|awaiting_upload][&limit=100]
- *
- * Respuesta:
- *   { ok:true, rows:[{ id, org_id, patient_id, title, status, due_at, created_at, lab_results:[{ path }] }] }
- * - Incluye la relación lab_results(path) para saber si ya hay archivo subido.
- * - Requiere sesión válida (auth.user) y org_id.
- */
-export async function GET(req: Request) {
-  const supa = createRouteHandlerClient({ cookies });
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  // Autenticación (evita filtrar datos a anónimos)
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) {
-    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
+
+    const url = new URL(req.url);
+    const orgId = url.searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
+
+    const patientId = url.searchParams.get("patient_id") || undefined;
+    const status = url.searchParams.get("status") || undefined;
+    const createdFrom = url.searchParams.get("from") || undefined;
+    const createdTo = url.searchParams.get("to") || undefined;
+
+    const limitRaw = Number(url.searchParams.get("limit") || 100);
+    const limit = Number.isFinite(limitRaw) ? Math.min(200, Math.max(1, limitRaw)) : 100;
+
+    let query = supa
+      .from("lab_requests")
+      .select(
+        `
+        id, org_id, patient_id, title, status, due_at, created_at,
+        lab_results ( path )
+      `,
+      )
+      .eq("org_id", orgId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    if (patientId) {
+      query = query.eq("patient_id", patientId);
+    }
+    if (status) {
+      query = query.eq("status", status as any);
+    }
+    if (createdFrom) {
+      query = query.gte("created_at", createdFrom);
+    }
+    if (createdTo) {
+      query = query.lte("created_at", createdTo);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({ rows: data ?? [] });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
-
-  const { searchParams } = new URL(req.url);
-  const org_id = searchParams.get("org_id") || "";
-  const patient_id = searchParams.get("patient_id") || undefined;
-  const status = searchParams.get("status") || undefined;
-
-  // Límite seguro (1–200, por defecto 100)
-  const limitRaw = Number(searchParams.get("limit") || 100);
-  const limit = Number.isFinite(limitRaw) ? Math.min(200, Math.max(1, limitRaw)) : 100;
-
-  if (!org_id) {
-    return NextResponse.json({ error: "org_id requerido" }, { status: 400 });
-  }
-
-  // Selecciona columnas + relación con resultados (para saber si hay archivo)
-  let q = supa
-    .from("lab_requests")
-    .select(
-      `
-      id, org_id, patient_id, title, status, due_at, created_at,
-      lab_results ( path )
-    `,
-    )
-    .eq("org_id", org_id)
-    .order("created_at", { ascending: false })
-    .limit(limit);
-
-  if (patient_id) q = q.eq("patient_id", patient_id);
-  if (status) q = q.eq("status", status as any);
-
-  const { data, error } = await q;
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
-  }
-
-  return NextResponse.json({ ok: true, rows: data ?? [] });
 }

--- a/app/api/lab/results/sign/route.ts
+++ b/app/api/lab/results/sign/route.ts
@@ -1,22 +1,40 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { createServiceClient } from "@/lib/supabase/server";
+import { ok, badRequest, serverError, error as jsonError } from "@/lib/api/responses";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const bucket = process.env.LAB_RESULTS_BUCKET || "lab-results";
+const schema = z.object({
+  path: z.string().min(1, "path requerido"),
+  expires: z.coerce.number().int().min(5).max(60 * 60 * 24).optional(),
+});
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const supa = createServiceClient();
+
   try {
-    const { path, expires = Number(process.env.NEXT_PUBLIC_SIGNED_URL_TTL || 300) } =
-      await req.json();
-    if (!path) return NextResponse.json({ error: "path requerido" }, { status: 400 });
-    const supa = createClient(url, serviceKey, { auth: { persistSession: false } });
+    const json = await req.json().catch(() => null);
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
+
+    const { path, expires } = parsed.data;
+    const ttl = expires ?? Number(process.env.NEXT_PUBLIC_SIGNED_URL_TTL || 300);
     const { data, error } = await supa.storage
       .from(bucket)
-      .createSignedUrl(path, Math.max(5, Number(expires)));
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    return NextResponse.json({ ok: true, url: data.signedUrl });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || "No se pudo firmar" }, { status: 500 });
+      .createSignedUrl(path, Math.max(5, Number(ttl)));
+
+    if (error) {
+      return jsonError("STORAGE_ERROR", error.message);
+    }
+
+    if (!data?.signedUrl) {
+      return serverError("No se pudo generar URL firmada");
+    }
+
+    return ok({ url: data.signedUrl });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
 }

--- a/app/api/lab/templates/route.ts
+++ b/app/api/lab/templates/route.ts
@@ -1,72 +1,160 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, badRequest, dbError, serverError, notFound } from "@/lib/api/responses";
 
-/**
- * Tabla sugerida: lab_test_templates
- *   id uuid pk default gen_random_uuid()
- *   org_id uuid null
- *   created_by uuid not null
- *   name text not null
- *   notes text null
- *   items jsonb not null default '[]'   -- [{code?, name, notes?}]
- *   is_active boolean not null default true
- *   created_at timestamptz default now()
- *   updated_at timestamptz default now()
- */
+const templateSchema = z.object({
+  id: z.string().uuid().optional(),
+  org_id: z.string().min(1).optional(),
+  name: z.string().min(1, "name requerido"),
+  notes: z.string().optional().nullable(),
+  items: z
+    .array(
+      z.object({
+        code: z.string().optional().nullable(),
+        name: z.string().min(1, "name requerido"),
+        notes: z.string().optional().nullable(),
+      }),
+    )
+    .default([]),
+  is_active: z.boolean().optional(),
+});
 
-export async function GET() {
-  const supa = createRouteHandlerClient({ cookies });
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+const deleteSchema = z.object({
+  id: z.string().min(1, "id requerido"),
+  org_id: z.string().optional(),
+});
 
-  const { data, error } = await supa
-    .from("lab_test_templates")
-    .select("id, name, notes, items, is_active, created_at")
-    .order("created_at", { ascending: false });
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ ok: true, rows: data });
-}
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-export async function POST(req: Request) {
-  const supa = createRouteHandlerClient({ cookies });
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    const orgId = new URL(req.url).searchParams.get("org_id") || undefined;
 
-  const body = await req.json().catch(() => ({}));
-  const { id, name, notes = "", items = [], is_active = true } = body;
-
-  if (!name || !Array.isArray(items))
-    return NextResponse.json({ error: "name e items (array) requeridos" }, { status: 400 });
-
-  if (id) {
-    const { error } = await supa
+    let query = supa
       .from("lab_test_templates")
-      .update({ name, notes, items, is_active, updated_at: new Date().toISOString() })
-      .eq("id", id);
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    return NextResponse.json({ ok: true, id });
-  } else {
-    const { data, error } = await supa
-      .from("lab_test_templates")
-      .insert({ name, notes, items, is_active, created_by: auth.user.id })
-      .select("id")
-      .single();
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    return NextResponse.json({ ok: true, id: data.id });
+      .select("id, org_id, name, notes, items, is_active, created_at")
+      .order("created_at", { ascending: false });
+
+    if (orgId) {
+      query = query.eq("org_id", orgId);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({ rows: data ?? [] });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
 }
 
-export async function DELETE(req: Request) {
-  const supa = createRouteHandlerClient({ cookies });
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  const { id } = await req.json().catch(() => ({}));
-  if (!id) return NextResponse.json({ error: "id requerido" }, { status: 400 });
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const { error } = await supa.from("lab_test_templates").delete().eq("id", id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ ok: true });
+    const json = await req.json().catch(() => null);
+    const parsed = templateSchema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
+
+    const { id, org_id, name, notes = "", items, is_active = true } = parsed.data;
+    const nowIso = new Date().toISOString();
+    const basePayload = {
+      org_id: org_id ?? null,
+      name,
+      notes,
+      items,
+      is_active,
+      updated_at: nowIso,
+    };
+
+    if (id) {
+      const { data, error } = await supa
+        .from("lab_test_templates")
+        .update(basePayload)
+        .eq("id", id)
+        .select("id")
+        .maybeSingle();
+
+      if (error) {
+        return dbError(error);
+      }
+
+      if (!data) {
+        return notFound("Plantilla no encontrada");
+      }
+
+      return ok({ id: data.id });
+    }
+
+    const insertPayload = {
+      ...basePayload,
+      created_by: auth.user.id,
+    };
+
+    const { data, error } = await supa
+      .from("lab_test_templates")
+      .insert(insertPayload)
+      .select("id")
+      .single();
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({ id: data.id });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const supa = await getSupabaseServer();
+
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
+
+    const json = await req.json().catch(() => null);
+    const parsed = deleteSchema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
+
+    const { id, org_id } = parsed.data;
+
+    let query = supa.from("lab_test_templates").delete().eq("id", id);
+    if (org_id) {
+      query = query.eq("org_id", org_id);
+    }
+
+    const { error, count } = await query.select("id", { count: "exact" });
+    if (error) {
+      return dbError(error);
+    }
+
+    if (!count) {
+      return notFound("Plantilla no encontrada");
+    }
+
+    return ok();
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
 }

--- a/app/api/lab/templates/upsert/route.ts
+++ b/app/api/lab/templates/upsert/route.ts
@@ -1,50 +1,76 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, badRequest, dbError, serverError } from "@/lib/api/responses";
 
-/**
- * POST /api/lab/templates/upsert
- * Body: { id?, org_id, owner_kind: "user"|"org", title, items:[{ code?, name, notes? }], is_active? }
- * - Si llega id → actualiza (solo si es del mismo owner)
- * - Sin id → crea
- */
-export async function POST(req: Request) {
-  const supa = createRouteHandlerClient({ cookies });
-  const { data: auth } = await supa.auth.getUser();
-  if (!auth.user) return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+const schema = z.object({
+  id: z.string().uuid().optional(),
+  org_id: z.string().min(1, "org_id requerido"),
+  owner_kind: z.enum(["user", "org"], { errorMap: () => ({ message: "owner_kind inválido" }) }),
+  title: z.string().min(1, "title requerido"),
+  items: z
+    .array(
+      z.object({
+        code: z.string().optional().nullable(),
+        name: z.string().min(1, "name requerido"),
+        notes: z.string().optional().nullable(),
+      }),
+    )
+    .min(1, "items requerido"),
+  is_active: z.boolean().optional(),
+});
 
-  const b = await req.json().catch(() => ({}));
-  const { id, org_id, owner_kind, title, items, is_active = true } = b;
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  if (!org_id || !owner_kind || !title || !Array.isArray(items)) {
-    return NextResponse.json(
-      { error: "org_id, owner_kind, title, items requeridos" },
-      { status: 400 },
-    );
-  }
-  if (!["user", "org"].includes(owner_kind)) {
-    return NextResponse.json({ error: "owner_kind inválido" }, { status: 400 });
-  }
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const payload = {
-    org_id,
-    owner_kind,
-    owner_id: owner_kind === "user" ? auth.user.id : null,
-    title,
-    items,
-    is_active: !!is_active,
-  };
+    const json = await req.json().catch(() => null);
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
 
-  if (id) {
-    // seguridad: sólo permite actualizar si eres el dueño
-    let q = supa.from("lab_templates").update(payload).eq("id", id).eq("org_id", org_id);
-    if (owner_kind === "user") q = q.eq("owner_id", auth.user.id);
-    const { error } = await q;
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    return NextResponse.json({ ok: true, id });
-  } else {
-    const { data, error } = await supa.from("lab_templates").insert(payload).select("id").single();
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    return NextResponse.json({ ok: true, id: data.id });
+    const { id, org_id, owner_kind, title, items, is_active = true } = parsed.data;
+    const payload = {
+      org_id,
+      owner_kind,
+      owner_id: owner_kind === "user" ? auth.user.id : null,
+      title,
+      items,
+      is_active,
+    };
+
+    if (id) {
+      let query = supa.from("lab_templates").update(payload).eq("id", id).eq("org_id", org_id);
+      if (owner_kind === "user") {
+        query = query.eq("owner_id", auth.user.id);
+      }
+
+      const { error } = await query;
+      if (error) {
+        return dbError(error);
+      }
+
+      return ok({ id });
+    }
+
+    const { data, error } = await supa
+      .from("lab_templates")
+      .insert(payload)
+      .select("id")
+      .single();
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return ok({ id: data.id });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
 }

--- a/app/api/labs/requests/[id]/json/route.ts
+++ b/app/api/labs/requests/[id]/json/route.ts
@@ -1,57 +1,102 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest } from "next/server";
+import { ok, badRequest, unauthorized, notFound, dbError, serverError } from "@/lib/api/responses";
+import { getSupabaseServer } from "@/lib/supabase/server";
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const id = params.id;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
 
-  const { data: req } = await supabase.from("lab_requests").select("*").eq("id", id).maybeSingle();
-  if (!req) return NextResponse.json({ error: "No encontrada" }, { status: 404 });
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const { data: items } = await supabase
-    .from("lab_request_items")
-    .select("*")
-    .eq("request_id", id)
-    .order("id");
+    const orgId = new URL(req.url).searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
 
-  const { data: patient } = await supabase
-    .from("patients")
-    .select("full_name, external_id")
-    .eq("id", req.patient_id)
-    .maybeSingle();
-
-  // Usa el mismo esquema de membretes/firmas que recetas/interconsulta/alta
-  const { data: letterhead } = await supabase
-    .from("doctor_letterheads")
-    .select("*")
-    .eq("org_id", req.org_id)
-    .eq("doctor_id", req.requested_by)
-    .maybeSingle();
-
-  // Disclaimer por tipo "labs"
-  let footer = letterhead?.footer_disclaimer || "";
-  if (!footer) {
-    const { data: d } = await supabase
-      .from("org_disclaimers")
-      .select("text")
-      .eq("org_id", req.org_id)
-      .eq("kind", "labs")
+    const { data: request, error: requestError } = await supa
+      .from("lab_requests")
+      .select("*")
+      .eq("id", params.id)
+      .eq("org_id", orgId)
       .maybeSingle();
-    footer = d?.text || footer;
+
+    if (requestError) {
+      return dbError(requestError);
+    }
+
+    if (!request) {
+      return notFound("Solicitud no encontrada");
+    }
+
+    const [{ data: items, error: itemsError }, { data: patient, error: patientError }] = await Promise.all([
+      supa
+        .from("lab_request_items")
+        .select("*")
+        .eq("request_id", params.id)
+        .order("id"),
+      supa
+        .from("patients")
+        .select("full_name, external_id")
+        .eq("id", request.patient_id)
+        .maybeSingle(),
+    ]);
+
+    if (itemsError) {
+      return dbError(itemsError);
+    }
+
+    if (patientError) {
+      return dbError(patientError);
+    }
+
+    const { data: letterhead, error: letterheadError } = await supa
+      .from("doctor_letterheads")
+      .select("*")
+      .eq("org_id", request.org_id)
+      .eq("doctor_id", request.requested_by)
+      .maybeSingle();
+
+    if (letterheadError) {
+      return dbError(letterheadError);
+    }
+
+    let footer = letterhead?.footer_disclaimer || "";
+    if (!footer) {
+      const { data: disclaimer, error: disclaimerError } = await supa
+        .from("org_disclaimers")
+        .select("text")
+        .eq("org_id", request.org_id)
+        .eq("kind", "labs")
+        .maybeSingle();
+
+      if (disclaimerError) {
+        return dbError(disclaimerError);
+      }
+
+      footer = disclaimer?.text || footer;
+    }
+
+    const { data: ledger, error: ledgerError } = await supa.rpc("ensure_document_folio", {
+      p_doc_type: "lab_request",
+      p_doc_id: params.id,
+    });
+
+    if (ledgerError) {
+      return dbError(ledgerError);
+    }
+
+    return ok({
+      request,
+      items: items ?? [],
+      patient,
+      letterhead,
+      footer,
+      ledger,
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
   }
-
-  const { data: ledger } = await supabase.rpc("ensure_document_folio", {
-    p_doc_type: "lab_request",
-    p_doc_id: id,
-  });
-
-  return NextResponse.json({
-    request: req,
-    items,
-    patient,
-    letterhead,
-    footer,
-    ledger,
-  });
 }

--- a/app/api/labs/requests/[id]/pdf/route.ts
+++ b/app/api/labs/requests/[id]/pdf/route.ts
@@ -1,147 +1,214 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { NextRequest, NextResponse } from "next/server";
 import { newPdf, pngFromDataUrl, makeQrDataUrl, drawWrappedText } from "@/lib/pdf";
+import { badRequest, unauthorized, notFound, dbError, serverError } from "@/lib/api/responses";
+import { getSupabaseServer } from "@/lib/supabase/server";
 
 async function signedBuf(supabase: any, bucket: string, key: string) {
   const k = key.replace(new RegExp(`^${bucket}/`), "");
-  const { data } = await supabase.storage.from(bucket).createSignedUrl(k, 60);
+  const { data, error } = await supabase.storage.from(bucket).createSignedUrl(k, 60);
+  if (error) throw error;
   if (!data?.signedUrl) return null;
   const r = await fetch(data.signedUrl);
   if (!r.ok) return null;
   return await r.arrayBuffer();
 }
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const id = params.id;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await getSupabaseServer();
 
-  const { data: req } = await supabase.from("lab_requests").select("*").eq("id", id).maybeSingle();
-  if (!req) return NextResponse.json({ error: "No encontrada" }, { status: 404 });
+  try {
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
+    }
 
-  const { data: items } = await supabase
-    .from("lab_request_items")
-    .select("*")
-    .eq("request_id", id)
-    .order("id");
-  const { data: pat } = await supabase
-    .from("patients")
-    .select("full_name, external_id")
-    .eq("id", req.patient_id)
-    .maybeSingle();
-  const { data: lh } = await supabase
-    .from("doctor_letterheads")
-    .select("*")
-    .eq("org_id", req.org_id)
-    .eq("doctor_id", req.requested_by)
-    .maybeSingle();
+    const orgId = new URL(req.url).searchParams.get("org_id");
+    if (!orgId) {
+      return badRequest("org_id requerido");
+    }
 
-  let footer = lh?.footer_disclaimer || "";
-  if (!footer) {
-    const { data: d } = await supabase
-      .from("org_disclaimers")
-      .select("text")
-      .eq("org_id", req.org_id)
-      .eq("kind", "labs")
+    const { data: request, error: requestError } = await supabase
+      .from("lab_requests")
+      .select("*")
+      .eq("id", params.id)
+      .eq("org_id", orgId)
       .maybeSingle();
-    footer = d?.text || footer;
-  }
 
-  const { data: led } = await supabase.rpc("ensure_document_folio", {
-    p_doc_type: "lab_request",
-    p_doc_id: id,
-  });
-  const verifyUrl = `${process.env.NEXT_PUBLIC_APP_URL || ""}/api/docs/verify?type=lab_request&id=${id}&code=${led.verify_code}`;
-  const qrDataUrl = await makeQrDataUrl(verifyUrl);
-
-  const { pdf, page, bold, W, H } = await newPdf();
-  let y = H - 40;
-
-  // Encabezado
-  if (lh?.logo_url) {
-    const ab = await signedBuf(supabase, "letterheads", lh.logo_url);
-    if (ab) {
-      const img = await pdf.embedPng(ab);
-      const w = 120,
-        h = (img.height / img.width) * w;
-      page.drawImage(img, { x: 40, y: y - h + 8, width: w, height: h });
+    if (requestError) {
+      return dbError(requestError);
     }
-  }
-  page.setFont(bold);
-  page.drawText(lh?.display_name || "Médico/a", { x: 180, y, size: 14 });
-  y -= 16;
-  if (lh?.credentials) {
-    page.drawText(lh.credentials, { x: 180, y, size: 10 });
-    y -= 12;
-  }
-  if (lh?.clinic_info) {
-    page.drawText(lh.clinic_info, { x: 180, y, size: 10 });
-    y -= 12;
-  }
-  page.drawText(`Folio: ${led.folio}`, { x: W - 160, y: H - 40, size: 10 });
-  page.drawText(new Date(req.created_at).toLocaleString(), { x: W - 160, y: H - 54, size: 10 });
 
-  // Título y paciente
-  y -= 8;
-  page.drawText("Solicitud de estudios de laboratorio", { x: 40, y, size: 12 });
-  y -= 14;
-  page.drawText(`Paciente: ${pat?.full_name || req.patient_id}`, { x: 40, y, size: 10 });
-  y -= 12;
-  if (pat?.external_id) {
-    page.drawText(`ID: ${pat.external_id}`, { x: 40, y, size: 10 });
-    y -= 12;
-  }
-  if (req.title) {
-    y = drawWrappedText(page, `Título: ${req.title}`, 40, y - 6, W - 80, 10);
-  }
-  if (req.instructions) {
-    y = drawWrappedText(page, `Instrucciones: ${req.instructions}`, 40, y - 6, W - 80, 10);
-  }
-  if (req.due_at) {
-    page.drawText(`Fecha límite: ${new Date(req.due_at).toLocaleString()}`, {
-      x: 40,
-      y: y - 6,
-      size: 10,
+    if (!request) {
+      return notFound("Solicitud no encontrada");
+    }
+
+    const [{ data: items, error: itemsError }, { data: patient, error: patientError }] = await Promise.all([
+      supabase
+        .from("lab_request_items")
+        .select("*")
+        .eq("request_id", params.id)
+        .order("id"),
+      supabase
+        .from("patients")
+        .select("full_name, external_id")
+        .eq("id", request.patient_id)
+        .maybeSingle(),
+    ]);
+
+    if (itemsError) {
+      return dbError(itemsError);
+    }
+
+    if (patientError) {
+      return dbError(patientError);
+    }
+
+    const { data: letterhead, error: letterheadError } = await supabase
+      .from("doctor_letterheads")
+      .select("*")
+      .eq("org_id", request.org_id)
+      .eq("doctor_id", request.requested_by)
+      .maybeSingle();
+
+    if (letterheadError) {
+      return dbError(letterheadError);
+    }
+
+    let footer = letterhead?.footer_disclaimer || "";
+    if (!footer) {
+      const { data: disclaimer, error: disclaimerError } = await supabase
+        .from("org_disclaimers")
+        .select("text")
+        .eq("org_id", request.org_id)
+        .eq("kind", "labs")
+        .maybeSingle();
+
+      if (disclaimerError) {
+        return dbError(disclaimerError);
+      }
+
+      footer = disclaimer?.text || footer;
+    }
+
+    const { data: ledger, error: ledgerError } = await supabase.rpc("ensure_document_folio", {
+      p_doc_type: "lab_request",
+      p_doc_id: params.id,
     });
-    y -= 18;
-  }
 
-  // Ítems solicitados
-  page.drawText("Estudios solicitados:", { x: 40, y, size: 12 });
-  y -= 14;
-  for (const it of items || []) {
-    let line = `• ${it.test_name || "(sin nombre)"}`;
-    if (it.test_code) line += ` [${it.test_code}]`;
-    y = drawWrappedText(page, line, 40, y, W - 200, 10);
-    if (it.notes) y = drawWrappedText(page, `   ${it.notes}`, 40, y, W - 200, 10);
-    y -= 4;
-  }
-
-  // Firma y QR
-  if (lh?.signature_url) {
-    const ab = await signedBuf(supabase, "signatures", lh.signature_url);
-    if (ab) {
-      const img = await pdf.embedPng(ab);
-      const w = 140,
-        h = (img.height / img.width) * w;
-      page.drawImage(img, { x: W - 40 - w, y: 90, width: w, height: h });
+    if (ledgerError) {
+      return dbError(ledgerError);
     }
+
+    const verifyUrl = `${process.env.NEXT_PUBLIC_APP_URL || ""}/api/docs/verify?type=lab_request&id=${params.id}&code=${
+      ledger?.verify_code
+    }`;
+    const qrDataUrl = await makeQrDataUrl(verifyUrl);
+
+    const { pdf, page, bold, W, H } = await newPdf();
+    let y = H - 40;
+
+    if (letterhead?.logo_url) {
+      try {
+        const ab = await signedBuf(supabase, "letterheads", letterhead.logo_url);
+        if (ab) {
+          const img = await pdf.embedPng(ab);
+          const w = 120;
+          const h = (img.height / img.width) * w;
+          page.drawImage(img, { x: 40, y: y - h + 8, width: w, height: h });
+        }
+      } catch {
+        // ignorar errores de logo
+      }
+    }
+
+    page.setFont(bold);
+    page.drawText(letterhead?.display_name || "Médico/a", { x: 180, y, size: 14 });
+    y -= 16;
+    if (letterhead?.credentials) {
+      page.drawText(letterhead.credentials, { x: 180, y, size: 10 });
+      y -= 12;
+    }
+    if (letterhead?.clinic_info) {
+      page.drawText(letterhead.clinic_info, { x: 180, y, size: 10 });
+      y -= 12;
+    }
+    if (ledger?.folio) {
+      page.drawText(`Folio: ${ledger.folio}`, { x: W - 160, y: H - 40, size: 10 });
+    }
+    page.drawText(new Date(request.created_at).toLocaleString(), { x: W - 160, y: H - 54, size: 10 });
+
+    y -= 8;
+    page.drawText("Solicitud de estudios de laboratorio", { x: 40, y, size: 12 });
+    y -= 14;
+    page.drawText(`Paciente: ${patient?.full_name || request.patient_id}`, { x: 40, y, size: 10 });
+    y -= 12;
+    if (patient?.external_id) {
+      page.drawText(`ID: ${patient.external_id}`, { x: 40, y, size: 10 });
+      y -= 12;
+    }
+    if (request.title) {
+      y = drawWrappedText(page, `Título: ${request.title}`, 40, y - 6, W - 80, 10);
+    }
+    if (request.instructions) {
+      y = drawWrappedText(page, `Instrucciones: ${request.instructions}`, 40, y - 6, W - 80, 10);
+    }
+    if (request.due_at) {
+      page.drawText(`Fecha límite: ${new Date(request.due_at).toLocaleString()}`, {
+        x: 40,
+        y: y - 6,
+        size: 10,
+      });
+      y -= 18;
+    }
+
+    page.drawText("Estudios solicitados:", { x: 40, y, size: 12 });
+    y -= 14;
+    for (const item of items ?? []) {
+      let line = `• ${item.test_name || "(sin nombre)"}`;
+      if (item.test_code) line += ` [${item.test_code}]`;
+      y = drawWrappedText(page, line, 40, y, W - 200, 10);
+      if (item.notes) y = drawWrappedText(page, `   ${item.notes}`, 40, y, W - 200, 10);
+      y -= 4;
+    }
+
+    if (letterhead?.signature_url) {
+      try {
+        const ab = await signedBuf(supabase, "signatures", letterhead.signature_url);
+        if (ab) {
+          const img = await pdf.embedPng(ab);
+          const w = 140;
+          const h = (img.height / img.width) * w;
+          page.drawImage(img, { x: W - 40 - w, y: 90, width: w, height: h });
+        }
+      } catch {
+        // ignorar errores de firma
+      }
+    }
+
+    if (qrDataUrl) {
+      const qr = await pngFromDataUrl(pdf, qrDataUrl);
+      page.drawImage(qr, { x: W - 160, y: 40, width: 100, height: 100 });
+      page.drawText("Verificar:", { x: W - 160, y: 144, size: 9 });
+      page.drawText(verifyUrl.slice(0, 46), { x: W - 160, y: 132, size: 8 });
+      if (verifyUrl.length > 46) {
+        page.drawText(verifyUrl.slice(46, 92), { x: W - 160, y: 122, size: 8 });
+      }
+    }
+
+    if (footer) {
+      page.drawText(footer.slice(0, 300), { x: 40, y: 60, size: 9 });
+    }
+
+    const bytes = await pdf.save();
+    return new NextResponse(bytes, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="lab_request_${request.id}.pdf"`,
+        "Cache-Control": "private, max-age=0",
+      },
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error generando PDF");
   }
-  const qr = await pngFromDataUrl(pdf, qrDataUrl);
-  page.drawImage(qr, { x: W - 160, y: 40, width: 100, height: 100 });
-  page.drawText("Verificar:", { x: W - 160, y: 144, size: 9 });
-  page.drawText(verifyUrl.slice(0, 46), { x: W - 160, y: 132, size: 8 });
-  if (verifyUrl.length > 46)
-    page.drawText(verifyUrl.slice(46, 92), { x: W - 160, y: 122, size: 8 });
-
-  if (footer) page.drawText(footer.slice(0, 300), { x: 40, y: 60, size: 9 });
-
-  const bytes = await pdf.save();
-  return new NextResponse(bytes, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `attachment; filename="lab_request_${req.id}.pdf"`,
-    },
-  });
 }

--- a/app/api/prescriptions/check-interactions/route.ts
+++ b/app/api/prescriptions/check-interactions/route.ts
@@ -1,99 +1,116 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-
-type ProposedItem = { drug: string };
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { ok, unauthorized, badRequest, forbidden, serverError } from "@/lib/api/responses";
+import { userBelongsToOrg } from "@/lib/api/orgs";
 
 const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
 
-export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient({ cookies });
-  const body = await req.json().catch(() => null);
-  const { patient_id, items = [] } = (body || {}) as { patient_id: string; items: ProposedItem[] };
-  if (!patient_id || !Array.isArray(items))
-    return NextResponse.json({ error: "bad_request" }, { status: 400 });
+const schema = z.object({
+  org_id: z.string().min(1, "org_id requerido"),
+  patient_id: z.string().min(1, "patient_id requerido"),
+  items: z.array(z.object({ drug: z.string().min(1, "drug requerido") })).default([]),
+});
 
-  // Condiciones y medicamentos actuales del paciente
-  const [condsRes, medsRes] = await Promise.all([
-    supabase
-      .from("patient_conditions")
-      .select("concept:concept_dictionary(id, canonical, canonical_norm)")
-      .eq("patient_id", patient_id),
-    supabase.from("patient_medications").select("name").eq("patient_id", patient_id),
-  ]);
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
 
-  const conditions = (condsRes.data || []).map((c: any) => c.concept?.id).filter(Boolean);
-  const currentMeds = (medsRes.data || []).map((m: any) => String(m.name || ""));
-
-  // Resolución por nombre normalizado
-  const names = Array.from(
-    new Set([...currentMeds, ...items.map((i) => i.drug)].map(norm).filter(Boolean)),
-  );
-
-  const { data: dict } = await supabase
-    .from("drug_dictionary")
-    .select("id, kind, name_norm, synonyms")
-    .in("name_norm", names);
-
-  // map name_norm -> ingredient ids
-  const nameToIngredientIds = new Map<string, string[]>();
-  for (const d of dict || []) {
-    if (d.kind === "ingredient") nameToIngredientIds.set(d.name_norm, [d.id]);
-  }
-  // try synonyms
-  for (const nm of names) {
-    if (!nameToIngredientIds.has(nm)) {
-      const hit = (dict || []).find(
-        (d) => d.kind === "ingredient" && (d.synonyms || []).map(norm).includes(nm),
-      );
-      if (hit) nameToIngredientIds.set(nm, [hit.id]);
+  try {
+    const { data: auth } = await supa.auth.getUser();
+    if (!auth?.user) {
+      return unauthorized();
     }
-  }
 
-  const proposedIngr = items.map((i) => nameToIngredientIds.get(norm(i.drug)) || []).flat();
-  const currentIngr = currentMeds.map((n) => nameToIngredientIds.get(norm(n)) || []).flat();
+    const json = await req.json().catch(() => null);
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      return badRequest("Payload inválido", { details: parsed.error.flatten() });
+    }
 
-  // DD
-  let ddWarnings: any[] = [];
-  if (proposedIngr.length && currentIngr.length) {
-    const pairs = new Map<string, { a: string; b: string }>();
-    for (const a of proposedIngr)
-      for (const b of currentIngr) {
-        const key = [a, b].sort().join("#");
-        pairs.set(key, { a, b });
-      }
-    const arr = Array.from(pairs.values());
-    if (arr.length) {
-      const { data } = await supabase
-        .from("drug_interactions")
-        .select("a_ingredient, b_ingredient, severity, note")
-        .in(
-          "a_ingredient",
-          arr.map((x) => x.a),
-        )
-        .in(
-          "b_ingredient",
-          arr.map((x) => x.b),
+    const { org_id, patient_id, items } = parsed.data;
+    const allowed = await userBelongsToOrg(supa, org_id, auth.user.id);
+    if (!allowed) {
+      return forbidden("Sin acceso a la organización");
+    }
+
+    const [condsRes, medsRes] = await Promise.all([
+      supa
+        .from("patient_conditions")
+        .select("concept:concept_dictionary(id, canonical, canonical_norm)")
+        .eq("patient_id", patient_id)
+        .eq("org_id", org_id),
+      supa.from("patient_medications").select("name").eq("patient_id", patient_id).eq("org_id", org_id),
+    ]);
+
+    if (condsRes.error) throw condsRes.error;
+    if (medsRes.error) throw medsRes.error;
+
+    const conditions = (condsRes.data || []).map((c: any) => c.concept?.id).filter(Boolean);
+    const currentMeds = (medsRes.data || []).map((m: any) => String(m.name || ""));
+
+    const names = Array.from(new Set([...currentMeds, ...items.map((i) => i.drug)].map(norm).filter(Boolean)));
+
+    const { data: dict, error: dictError } = await supa
+      .from("drug_dictionary")
+      .select("id, kind, name_norm, synonyms")
+      .in("name_norm", names);
+
+    if (dictError) throw dictError;
+
+    const nameToIngredientIds = new Map<string, string[]>();
+    for (const d of dict || []) {
+      if (d.kind === "ingredient") nameToIngredientIds.set(d.name_norm, [d.id]);
+    }
+    for (const nm of names) {
+      if (!nameToIngredientIds.has(nm)) {
+        const hit = (dict || []).find(
+          (d) => d.kind === "ingredient" && (d.synonyms || []).map(norm).includes(nm),
         );
-      ddWarnings = data || [];
+        if (hit) nameToIngredientIds.set(nm, [hit.id]);
+      }
     }
-  }
 
-  // DC
-  let dcWarnings: any[] = [];
-  if (proposedIngr.length && conditions.length) {
-    const { data } = await supabase
-      .from("drug_condition_alerts")
-      .select("ingredient_id, condition_concept_id, severity, note")
-      .in("ingredient_id", proposedIngr)
-      .in("condition_concept_id", conditions);
-    dcWarnings = data || [];
-  }
+    const proposedIngr = items.map((i) => nameToIngredientIds.get(norm(i.drug)) || []).flat();
+    const currentIngr = currentMeds.map((n) => nameToIngredientIds.get(norm(n)) || []).flat();
 
-  return NextResponse.json({
-    warnings: {
-      drug_drug: ddWarnings,
-      drug_condition: dcWarnings,
-    },
-  });
+    let ddWarnings: any[] = [];
+    if (proposedIngr.length && currentIngr.length) {
+      const pairs = new Map<string, { a: string; b: string }>();
+      for (const a of proposedIngr)
+        for (const b of currentIngr) {
+          const key = [a, b].sort().join("#");
+          pairs.set(key, { a, b });
+        }
+      const arr = Array.from(pairs.values());
+      if (arr.length) {
+        const { data, error } = await supa
+          .from("drug_interactions")
+          .select("a_ingredient, b_ingredient, severity, note")
+          .in("a_ingredient", arr.map((x) => x.a))
+          .in("b_ingredient", arr.map((x) => x.b));
+        if (error) throw error;
+        ddWarnings = data || [];
+      }
+    }
+
+    let dcWarnings: any[] = [];
+    if (proposedIngr.length && conditions.length) {
+      const { data, error } = await supa
+        .from("drug_condition_alerts")
+        .select("ingredient_id, condition_concept_id, severity, note")
+        .in("ingredient_id", proposedIngr)
+        .in("condition_concept_id", conditions);
+      if (error) throw error;
+      dcWarnings = data || [];
+    }
+
+    return ok({
+      warnings: {
+        drug_drug: ddWarnings,
+        drug_condition: dcWarnings,
+      },
+    });
+  } catch (err: any) {
+    return serverError(err?.message ?? "Error");
+  }
 }

--- a/lib/api/orgs.ts
+++ b/lib/api/orgs.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function userBelongsToOrg(
+  supa: SupabaseClient<any, any, any>,
+  orgId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!orgId || !userId) return false;
+
+  const { data, error } = await supa
+    .from("organization_members")
+    .select("org_id")
+    .eq("org_id", orgId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!error && data?.org_id === orgId) {
+    return true;
+  }
+
+  if (error && error.code && error.code !== "PGRST116") {
+    throw error;
+  }
+
+  const { data: legacy, error: legacyError } = await supa
+    .from("v_my_orgs")
+    .select("id")
+    .eq("id", orgId)
+    .maybeSingle();
+
+  if (legacyError && legacyError.code && legacyError.code !== "PGRST116") {
+    throw legacyError;
+  }
+
+  return !!legacy?.id;
+}

--- a/lib/api/responses.ts
+++ b/lib/api/responses.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+type JsonObject = Record<string, unknown> | undefined;
+
+type ErrorExtras = JsonObject & {
+  details?: JsonObject;
+};
+
+function build(body: Record<string, unknown>, init?: ResponseInit) {
+  return NextResponse.json(body, init);
+}
+
+export function ok(payload?: JsonObject, init?: ResponseInit) {
+  return build({ ok: true, ...(payload ?? {}) }, init);
+}
+
+export function error(
+  code: string,
+  message: string,
+  status = 400,
+  extras?: ErrorExtras,
+) {
+  const { details, ...rest } = extras ?? {};
+  return build(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        ...(details ? { details } : {}),
+      },
+      ...rest,
+    },
+    { status },
+  );
+}
+
+export function badRequest(message: string, extras?: ErrorExtras) {
+  return error("BAD_REQUEST", message, 400, extras);
+}
+
+export function unauthorized(message = "No autenticado", extras?: ErrorExtras) {
+  return error("UNAUTHORIZED", message, 401, extras);
+}
+
+export function forbidden(message = "No autorizado", extras?: ErrorExtras) {
+  return error("FORBIDDEN", message, 403, extras);
+}
+
+export function notFound(message = "No encontrado", extras?: ErrorExtras) {
+  return error("NOT_FOUND", message, 404, extras);
+}
+
+export function conflict(message = "Conflicto", extras?: ErrorExtras) {
+  return error("CONFLICT", message, 409, extras);
+}
+
+export function serverError(message = "Error", extras?: ErrorExtras) {
+  return error("SERVER_ERROR", message, 500, extras);
+}
+
+export function dbError(err: { message?: string } | null, extras?: ErrorExtras) {
+  const message = err?.message || "Error en base de datos";
+  return error("DB_ERROR", message, 400, extras);
+}


### PR DESCRIPTION
## Summary
- add reusable API helpers for consistent JSON responses and org membership validation
- migrate lab and discharge route handlers to the new helpers and enforce org_id checks
- update lab result signing/upload flows to use the service client and stricter payload validation

## Testing
- pnpm lint *(fails: Missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dafd25d600832aa3fd5519ae4c0544