### PR TITLE
Add HTTP validation helpers, rate limiting middleware, and routes documentation

### DIFF
--- a/docs/ops/ROUTES_MODE.md
+++ b/docs/ops/ROUTES_MODE.md
@@ -1,0 +1,72 @@
+# ROUTES_MODE — Matriz de endpoints → MODE (session/service)
+
+> Estándar: Next 15 (cookies async), handlers `export async`, helpers:
+> - MODE **session** → `const supa = await getSupabaseServer()` (lee cookies; respeta RLS `auth.uid()`).
+> - MODE **service** → `const svc = createServiceClient()` (NO cookies; uso con `x-cron-key`/firma).
+
+## Clínico — Prescriptions (Recetas) → **session**
+- /api/prescriptions/check-interactions      (GET/POST)
+- /api/prescriptions/[id]/json               (GET)
+- /api/prescriptions/[id]/pdf                (GET) → Headers PDF
+- /api/prescriptions/create                  (POST) → zod payload
+- /api/prescriptions/templates               (GET/POST?) plantillas por org
+- /api/prescriptions/from-template           (POST)
+
+## Clínico — Discharges (Altas) → **session**
+- /api/discharges/[id]/json                  (GET)
+- /api/discharges/[id]/pdf                   (GET) → Headers PDF
+- /api/discharges/create                     (POST)
+- /api/discharges                            (GET) listado + paginación
+
+## Clínico — Referrals (Referencias) → **session**
+- /api/referrals/[id]                        (GET/DELETE?)
+- /api/referrals/[id]/json                   (GET) *(si existe)*
+- /api/referrals/create                      (POST)
+- /api/referrals/templates                   (GET)
+
+## Clínico — Forms → **session**
+- /api/forms/templates                       (GET/POST?)
+- /api/forms/responses                       (GET/POST?)
+
+## Agenda → **session** (lectura/escritura de usuario)
+- /api/agenda/appointments/*                 (GET/POST/PATCH)
+- /api/agenda/availability/*                 (GET)
+
+## Integraciones / Jobs / Webhooks → **service**
+- /api/integrations/jotform/webhook          (POST) → validar firma/`x-cron-key`
+- /api/integrations/twilio/*                 (POST) → validar firma Twilio
+- /api/cal/bookings                          (POST) → firma Cal.com
+- /api/jobs/*                                (POST) → `x-cron-key` requerido
+- /api/notify/*                              (POST) → `x-cron-key` / firma proveedor
+
+## Files / Storage / Export
+- /api/files/*                               (**session**) lectura/gestión user-scoped
+- /api/storage/letterheads/*                 (**session**) firma temporal + headers
+- /api/storage/signatures/*                  (**session**) firma temporal + headers
+- /api/export/*                              (**session**) CSV/XLSX con headers correctos
+
+## Bank (MVP)
+- /api/bank/tx*                              (**session**)
+- /api/bank/rules*                           (**session**)
+- /api/bank/budgets*                         (**session**)
+- /api/bank/report/*                         (**session**)
+- /api/bank/alerts/run                       (**service**) `x-cron-key`
+
+## Reports
+- /api/reports/*                             (**session**) excepto:
+- /api/reports/daily-summary/send            (**service**) `x-cron-key`
+
+## Docs / Utilidades
+- /api/docs/verify                           (**service**) (consulta pública controlada)
+- /api/docs/ensure-folio                     (**service**) folios seguros
+
+---
+
+### Reglas fijas del proyecto
+- Siempre `export async function GET/POST/...`.
+- MODE comentado en la primera línea del handler.
+- Respuestas JSON:
+  - Éxito: `{ ok: true, data?, meta? }`
+  - Error: `{ ok: false, error: { code, message } }` + `status`.
+- En **service**: nunca leer cookies; validar `x-cron-key` o firma del proveedor.
+- CSV/PDF: `Content-Type` y `Content-Disposition` correctos (filename).

--- a/lib/http/validate.ts
+++ b/lib/http/validate.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+/** -----------------------------
+ * Respuestas estándar JSON
+ * ------------------------------ */
+export function jsonOk<T>(data?: T, meta?: Record<string, unknown>) {
+  return NextResponse.json({ ok: true, data, ...(meta ? { meta } : {}) });
+}
+
+export function jsonError(code: string, message: string, status = 400, extra?: Record<string, unknown>) {
+  return NextResponse.json({ ok: false, error: { code, message, ...(extra || {}) } }, { status });
+}
+
+/** -----------------------------
+ * Utilidades de parseo
+ * ------------------------------ */
+export function getUrl(req: NextRequest) {
+  return new URL(req.url);
+}
+
+export function getQuery(req: NextRequest) {
+  return getUrl(req).searchParams;
+}
+
+export async function parseJson<T = unknown>(req: NextRequest): Promise<T | null> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** -----------------------------
+ * Zod helpers
+ * ------------------------------ */
+export function parseOrError<T>(schema: z.ZodType<T>, data: unknown) {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ");
+    return { ok: false as const, error: { code: "VALIDATION_ERROR", message: issues } };
+  }
+  return { ok: true as const, data: parsed.data as T };
+}
+
+/** -----------------------------
+ * Coerciones frecuentes
+ * ------------------------------ */
+export function asInt(v: string | null, fallback: number, opts?: { min?: number; max?: number }) {
+  const n = v != null ? Number.parseInt(v, 10) : Number.NaN;
+  if (Number.isNaN(n)) return fallback;
+  if (opts?.min != null && n < opts.min) return opts.min;
+  if (opts?.max != null && n > opts.max) return opts.max;
+  return n;
+}
+
+export function asBool(v: string | null, fallback = false) {
+  if (v == null) return fallback;
+  if (v === "1" || v.toLowerCase() === "true") return true;
+  if (v === "0" || v.toLowerCase() === "false") return false;
+  return fallback;
+}
+
+export function requireHeader(req: NextRequest, name: string, expected?: string) {
+  const val = req.headers.get(name);
+  if (!val) return { ok: false as const, error: { code: "UNAUTHORIZED", message: `Falta header ${name}` } };
+  if (expected && val !== expected) return { ok: false as const, error: { code: "UNAUTHORIZED", message: `Header ${name} inválido` } };
+  return { ok: true as const, value: val };
+}
+
+/** -----------------------------
+ * org_id helpers (query/body)
+ * ------------------------------ */
+export function readOrgIdFromQuery(req: NextRequest) {
+  const q = getQuery(req);
+  const org_id = q.get("org_id");
+  if (!org_id) return { ok: false as const, error: { code: "BAD_REQUEST", message: "org_id requerido" } };
+  return { ok: true as const, org_id };
+}
+
+export function ensureOrgId(org_id?: string | null) {
+  if (!org_id) return { ok: false as const, error: { code: "BAD_REQUEST", message: "org_id requerido" } };
+  return { ok: true as const, org_id };
+}
+
+/** -----------------------------
+ * Tipado de paginación simple
+ * ------------------------------ */
+export const PageQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});
+export type PageQuery = z.infer<typeof PageQuerySchema>;
+
+export function parsePageQuery(req: NextRequest): PageQuery {
+  const sp = getQuery(req);
+  const obj = { page: sp.get("page"), pageSize: sp.get("pageSize") };
+  const res = parseOrError(PageQuerySchema, obj);
+  return res.ok ? res.data : { page: 1, pageSize: 50 };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Rate limit mínimo para rutas automatizadas / webhooks.
+ * - No valida firma/keys (eso lo hacemos en cada handler).
+ * - Previene floods accidentales. Para producción considera Upstash/Redis.
+ */
+
+type Bucket = { count: number; resetAt: number };
+const WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 60_000); // 1 min
+const MAX_REQ = Number(process.env.RATE_LIMIT_MAX_REQ ?? 60);        // 60 req/min por IP+ruta
+const DISABLED = process.env.RATE_LIMIT_DISABLED === "1";
+
+const globalBuckets = globalThis as unknown as { __sanoaBuckets?: Map<string, Bucket> };
+if (!globalBuckets.__sanoaBuckets) globalBuckets.__sanoaBuckets = new Map();
+const buckets = globalBuckets.__sanoaBuckets;
+
+function getIp(req: NextRequest) {
+  return req.ip || req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+}
+
+export function middleware(req: NextRequest) {
+  if (DISABLED) return NextResponse.next();
+
+  // Sólo corre para matcher (ver config abajo)
+  const ip = getIp(req);
+  const key = `${ip}:${new URL(req.url).pathname}`;
+  const now = Date.now();
+
+  const b = buckets.get(key);
+  if (!b || now > b.resetAt) {
+    buckets.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return NextResponse.next();
+  }
+
+  if (b.count >= MAX_REQ) {
+    const res = NextResponse.json({ ok: false, error: { code: "RATE_LIMITED", message: "Too Many Requests" } }, { status: 429 });
+    res.headers.set("Retry-After", String(Math.ceil((b.resetAt - now) / 1000)));
+    return res;
+  }
+
+  b.count += 1;
+  buckets.set(key, b);
+  return NextResponse.next();
+}
+
+// Aplica sólo a rutas automatizadas / webhooks / notificaciones
+export const config = {
+  matcher: [
+    "/api/integrations/:path*",
+    "/api/jobs/:path*",
+    "/api/notify/:path*",
+  ],
+};


### PR DESCRIPTION
## Summary
- add shared HTTP validation helpers for consistent API responses and parsing
- introduce lightweight rate limiting middleware for automated routes
- document API routes and their MODE usage for operational clarity

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db550afd80832a82858a8179081499