### PR TITLE
Add work task management APIs and UI

### DIFF
--- a/app/(app)/trabajo/asignar/page.tsx
+++ b/app/(app)/trabajo/asignar/page.tsx
@@ -1,0 +1,14 @@
+// app/(app)/trabajo/asignar/page.tsx
+"use client";
+
+import AccentHeader from "@/components/ui/AccentHeader";
+import AssignForm from "@/components/work/AssignForm";
+
+export default function Page() {
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader title="Asignar tarea o ejercicio" subtitle="Elige una plantilla o crea una asignación ad-hoc." emojiToken="trabajo" />
+      <AssignForm />
+    </main>
+  );
+}

--- a/app/(app)/trabajo/paciente/[id]/page.tsx
+++ b/app/(app)/trabajo/paciente/[id]/page.tsx
@@ -1,0 +1,17 @@
+// app/(app)/trabajo/paciente/[id]/page.tsx
+"use client";
+
+import { useParams } from "next/navigation";
+import AccentHeader from "@/components/ui/AccentHeader";
+import PatientAssignments from "@/components/work/PatientAssignments";
+
+export default function Page() {
+  const params = useParams<{ id: string }>();
+  const patientId = params?.id;
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader title="Tareas del paciente" subtitle="Seguimiento y acciones rápidas." emojiToken="trabajo" />
+      {patientId ? <PatientAssignments patientId={patientId} /> : <p>Falta paciente</p>}
+    </main>
+  );
+}

--- a/app/(app)/trabajo/plantillas/page.tsx
+++ b/app/(app)/trabajo/plantillas/page.tsx
@@ -1,0 +1,14 @@
+// app/(app)/trabajo/plantillas/page.tsx
+"use client";
+
+import AccentHeader from "@/components/ui/AccentHeader";
+import TemplateEditor from "@/components/work/TemplateEditor";
+
+export default function Page() {
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader title="Plantillas de ejercicios/tareas" subtitle="Crea y gestiona tu biblioteca por módulo." emojiToken="carpeta" />
+      <TemplateEditor />
+    </main>
+  );
+}

--- a/app/api/work/assign/route.ts
+++ b/app/api/work/assign/route.ts
@@ -1,0 +1,67 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError, parseJson, parseOrError } from "@/lib/http/validate";
+
+const BodySchema = z.object({
+  org_id: z.string().uuid(),
+  patient_ids: z.array(z.string().uuid()).min(1),
+  provider_id: z.string().uuid().optional(), // default auth.uid()
+  module: z.enum(["mente", "equilibrio", "sonrisa", "pulso", "general"]).default("general"),
+  template_id: z.string().uuid().optional(),
+  title: z.string().min(1).max(200).optional(), // si ad-hoc
+  content: z.any().optional(),                  // si ad-hoc
+  due_at: z.string().datetime().optional(),
+  frequency: z.enum(["once", "daily", "weekly", "monthly"]).default("once"),
+  occurrences: z.coerce.number().int().min(1).max(100).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const body = await parseJson(req);
+  const parsed = parseOrError(BodySchema, body);
+  if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
+
+  const { data: me } = await supa.auth.getUser();
+  const provider = parsed.data.provider_id ?? me?.user?.id ?? null;
+  if (!provider) return jsonError("UNAUTHORIZED", "No provider", 401);
+
+  // Si viene template_id y no viene title/content, obtén contenido de la plantilla
+  let tplTitle: string | undefined = parsed.data.title;
+  let tplContent: any = parsed.data.content;
+  if (parsed.data.template_id && (!tplTitle || !tplContent)) {
+    const { data: tpl, error: e } = await supa
+      .from("work_templates")
+      .select("title, content")
+      .eq("id", parsed.data.template_id)
+      .single();
+    if (e) return jsonError("DB_ERROR", e.message, 400);
+    tplTitle = tplTitle ?? tpl?.title ?? "Tarea";
+    tplContent = tplContent ?? tpl?.content ?? {};
+  }
+
+  const rows = parsed.data.patient_ids.map(pid => ({
+    org_id: parsed.data.org_id,
+    patient_id: pid,
+    provider_id: provider,
+    module: parsed.data.module,
+    template_id: parsed.data.template_id ?? null,
+    title: tplTitle ?? parsed.data.title ?? "Tarea",
+    content: tplContent ?? parsed.data.content ?? {},
+    due_at: parsed.data.due_at ?? null,
+    frequency: parsed.data.frequency,
+    occurrences: parsed.data.occurrences ?? null,
+    notes: parsed.data.notes ?? null,
+    status: "active",
+  }));
+
+  const { data, error } = await supa
+    .from("work_assignments")
+    .insert(rows)
+    .select("id");
+
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk({ created: data?.length ?? 0, ids: data?.map(r => r.id) });
+}

--- a/app/api/work/assignments/[id]/route.ts
+++ b/app/api/work/assignments/[id]/route.ts
@@ -1,0 +1,42 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError, parseJson, parseOrError } from "@/lib/http/validate";
+
+const PatchSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  content: z.any().optional(),
+  due_at: z.string().datetime().nullable().optional(),
+  status: z.enum(["active", "paused", "completed", "canceled"]).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export async function PATCH(req: NextRequest, ctx: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const body = await parseJson(req);
+  const parsed = parseOrError(PatchSchema, body);
+  if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
+
+  const update = { ...parsed.data } as any;
+  if (update.status === "completed" && !update.due_at) {
+    update.last_done_at = new Date().toISOString();
+  }
+
+  const { data, error } = await supa
+    .from("work_assignments")
+    .update(update)
+    .eq("id", ctx.params.id)
+    .select("*")
+    .single();
+
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk(data);
+}
+
+export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const { data, error } = await supa.from("work_assignments").select("*").eq("id", ctx.params.id).single();
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk(data);
+}

--- a/app/api/work/assignments/route.ts
+++ b/app/api/work/assignments/route.ts
@@ -1,0 +1,49 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError } from "@/lib/http/validate";
+
+const QuerySchema = z.object({
+  org_id: z.string().uuid(),
+  patient_id: z.string().uuid().optional(),
+  module: z.enum(["mente", "equilibrio", "sonrisa", "pulso", "general"]).optional(),
+  status: z.enum(["active", "paused", "completed", "canceled"]).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  page: z.coerce.number().int().min(1).default(1),
+});
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const qp = new URL(req.url).searchParams;
+  const parsed = QuerySchema.safeParse({
+    org_id: qp.get("org_id"),
+    patient_id: qp.get("patient_id") || undefined,
+    module: qp.get("module") || undefined,
+    status: qp.get("status") || undefined,
+    limit: qp.get("limit") || undefined,
+    page: qp.get("page") || undefined,
+  });
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ");
+    return jsonError("VALIDATION_ERROR", msg, 400);
+  }
+  const { org_id, patient_id, module, status, limit, page } = parsed.data;
+
+  let sel = supa
+    .from("work_assignments")
+    .select("id, org_id, patient_id, provider_id, module, title, content, due_at, frequency, occurrences, notes, status, last_done_at, created_at", { count: "exact" })
+    .eq("org_id", org_id);
+
+  if (patient_id) sel = sel.eq("patient_id", patient_id);
+  if (module) sel = sel.eq("module", module);
+  if (status) sel = sel.eq("status", status);
+
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, error, count } = await sel.order("created_at", { ascending: false }).range(from, to);
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+
+  return jsonOk({ items: data, meta: { page, pageSize: limit, total: count ?? 0 } });
+}

--- a/app/api/work/events/route.ts
+++ b/app/api/work/events/route.ts
@@ -1,0 +1,44 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError, parseJson, parseOrError } from "@/lib/http/validate";
+
+const BodySchema = z.object({
+  org_id: z.string().uuid(),
+  assignment_id: z.string().uuid(),
+  kind: z.enum(["completed", "note", "skipped"]),
+  payload: z.any().optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const body = await parseJson(req);
+  const parsed = parseOrError(BodySchema, body);
+  if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
+
+  const { data: me } = await supa.auth.getUser();
+  const actor = me?.user?.id ?? null;
+
+  const { error: e1 } = await supa
+    .from("work_events")
+    .insert({
+      org_id: parsed.data.org_id,
+      assignment_id: parsed.data.assignment_id,
+      kind: parsed.data.kind,
+      payload: parsed.data.payload ?? {},
+      created_by: actor,
+    });
+  if (e1) return jsonError("DB_ERROR", e1.message, 400);
+
+  // Si es completado, marca en assignment
+  if (parsed.data.kind === "completed") {
+    const { error: e2 } = await supa
+      .from("work_assignments")
+      .update({ last_done_at: new Date().toISOString(), status: "completed" })
+      .eq("id", parsed.data.assignment_id);
+    if (e2) return jsonError("DB_ERROR", e2.message, 400);
+  }
+
+  return jsonOk({ logged: true });
+}

--- a/app/api/work/templates/[id]/route.ts
+++ b/app/api/work/templates/[id]/route.ts
@@ -1,0 +1,47 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError, parseJson, parseOrError } from "@/lib/http/validate";
+
+const PatchSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  content: z.any().optional(),
+  tags: z.array(z.string()).optional(),
+  is_active: z.boolean().optional(),
+});
+
+export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const { data, error } = await supa
+    .from("work_templates")
+    .select("*")
+    .eq("id", ctx.params.id)
+    .single();
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk(data);
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const body = await parseJson(req);
+  const parsed = parseOrError(PatchSchema, body);
+  if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
+
+  const { data, error } = await supa
+    .from("work_templates")
+    .update(parsed.data)
+    .eq("id", ctx.params.id)
+    .select("*")
+    .single();
+
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk(data);
+}
+
+export async function DELETE(_req: NextRequest, ctx: { params: { id: string } }) {
+  const supa = await getSupabaseServer();
+  const { error } = await supa.from("work_templates").delete().eq("id", ctx.params.id);
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk({ deleted: true });
+}

--- a/app/api/work/templates/route.ts
+++ b/app/api/work/templates/route.ts
@@ -1,0 +1,70 @@
+// MODE: session (user-scoped, cookies)
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getSupabaseServer } from "@/lib/supabase/server";
+import { jsonOk, jsonError, parseJson, parseOrError } from "@/lib/http/validate";
+
+const QuerySchema = z.object({
+  org_id: z.string().uuid(),
+  module: z.enum(["mente", "equilibrio", "sonrisa", "pulso", "general"]).optional(),
+  q: z.string().optional(),
+  active: z.coerce.boolean().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+const BodySchema = z.object({
+  org_id: z.string().uuid(),
+  module: z.enum(["mente", "equilibrio", "sonrisa", "pulso", "general"]).default("general"),
+  title: z.string().min(1).max(200),
+  content: z.any(),           // JSON de ejercicios/tareas
+  tags: z.array(z.string()).optional().default([]),
+  is_active: z.boolean().optional().default(true),
+});
+
+export async function GET(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const qp = new URL(req.url).searchParams;
+  const parsed = QuerySchema.safeParse({
+    org_id: qp.get("org_id"),
+    module: qp.get("module") || undefined,
+    q: qp.get("q") || undefined,
+    active: qp.get("active") ?? undefined,
+    limit: qp.get("limit") ?? undefined,
+  });
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ");
+    return jsonError("VALIDATION_ERROR", msg, 400);
+  }
+  const { org_id, module, q, active, limit } = parsed.data;
+
+  let sel = supa
+    .from("work_templates")
+    .select("id, org_id, module, title, content, tags, is_active, created_by, created_at")
+    .eq("org_id", org_id)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (module) sel = sel.eq("module", module);
+  if (typeof active === "boolean") sel = sel.eq("is_active", active);
+  if (q && q.trim()) sel = sel.ilike("title", `%${q.trim()}%`);
+
+  const { data, error } = await sel;
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk(data);
+}
+
+export async function POST(req: NextRequest) {
+  const supa = await getSupabaseServer();
+  const body = await parseJson(req);
+  const parsed = parseOrError(BodySchema, body);
+  if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
+
+  const { data, error } = await supa
+    .from("work_templates")
+    .insert(parsed.data)
+    .select("id")
+    .single();
+
+  if (error) return jsonError("DB_ERROR", error.message, 400);
+  return jsonOk<{ id: string }>(data);
+}

--- a/components/work/AssignForm.tsx
+++ b/components/work/AssignForm.tsx
@@ -1,0 +1,140 @@
+// components/work/AssignForm.tsx
+"use client";
+
+import * as React from "react";
+import { listTemplates, type WorkTemplate } from "@/lib/work/templates";
+import { assignWork } from "@/lib/work/assignments";
+import { getActiveOrg } from "@/lib/org-local";
+import QuickBar from "@/components/patients/QuickBar";
+import ColorEmoji from "@/components/ColorEmoji";
+
+const MODULES = ["general", "mente", "equilibrio", "sonrisa", "pulso"] as const;
+
+export default function AssignForm() {
+  const org = getActiveOrg();
+  const [module, setModule] = React.useState<(typeof MODULES)[number]>("general");
+  const [templates, setTemplates] = React.useState<WorkTemplate[]>([]);
+  const [templateId, setTemplateId] = React.useState<string>("");
+  const [patientId, setPatientId] = React.useState<string>("");
+  const [title, setTitle] = React.useState("");
+  const [content, setContent] = React.useState("{}");
+  const [dueAt, setDueAt] = React.useState<string>("");
+  const [frequency, setFrequency] = React.useState<"once" | "daily" | "weekly" | "monthly">("once");
+  const [occ, setOcc] = React.useState<number | "">("");
+
+  React.useEffect(() => {
+    async function load() {
+      if (!org.id) return;
+      const list = await listTemplates({ org_id: org.id, module, active: true });
+      setTemplates(list);
+    }
+    load();
+  }, [org.id, module]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!org.id || !patientId) { alert("Falta organización o paciente"); return; }
+    let json: any = undefined;
+    if (!templateId) {
+      try { json = JSON.parse(content || "{}"); } catch { alert("Contenido JSON inválido"); return; }
+    }
+    const res = await assignWork({
+      org_id: org.id,
+      patient_ids: [patientId],
+      module,
+      template_id: templateId || undefined,
+      title: templateId ? undefined : (title || "Tarea"),
+      content: templateId ? undefined : json,
+      due_at: dueAt || undefined,
+      frequency,
+      occurrences: typeof occ === "number" ? occ : undefined,
+    });
+    if (res?.ok) {
+      alert("Asignado correctamente");
+      setTemplateId(""); setTitle(""); setContent("{}"); setDueAt(""); setFrequency("once"); setOcc("");
+    } else {
+      alert(res?.error?.message || "Error al asignar");
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="rounded-2xl border p-4 bg-white/95 dark:bg-slate-900/60 space-y-4">
+      <h3 className="font-semibold flex items-center gap-2"><ColorEmoji token="trabajo" /> Asignar tarea/ejercicio</h3>
+
+      <div className="space-y-2">
+        <div className="text-sm text-slate-500">Paciente</div>
+        {/* QuickBar navega por defecto; aquí solo queremos el id → usamos un input oculto + callback simple */}
+        <PatientPicker onPick={(id) => setPatientId(id)} />
+        {patientId ? <div className="text-xs text-green-600">Paciente seleccionado: {patientId}</div> : <div className="text-xs text-slate-500">Escribe para buscar…</div>}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-slate-500">Módulo</span>
+          <select value={module} onChange={e => setModule(e.target.value as any)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900">
+            {MODULES.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 md:col-span-2">
+          <span className="text-sm text-slate-500">Plantilla</span>
+          <select value={templateId} onChange={e => setTemplateId(e.target.value)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900">
+            <option value="">— Ad-hoc —</option>
+            {templates.map(t => <option key={t.id} value={t.id}>{t.title}</option>)}
+          </select>
+        </label>
+
+        {!templateId && (
+          <>
+            <label className="flex flex-col gap-1 md:col-span-3">
+              <span className="text-sm text-slate-500">Título</span>
+              <input value={title} onChange={e => setTitle(e.target.value)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900" />
+            </label>
+            <label className="flex flex-col gap-1 md:col-span-3">
+              <span className="text-sm text-slate-500">Contenido (JSON)</span>
+              <textarea value={content} onChange={e => setContent(e.target.value)} rows={5} className="rounded-xl border px-3 py-2 font-mono text-xs bg-white dark:bg-slate-900" />
+            </label>
+          </>
+        )}
+
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-slate-500">Vence (ISO)</span>
+          <input type="datetime-local" value={dueAt} onChange={e => setDueAt(e.target.value)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-slate-500">Frecuencia</span>
+          <select value={frequency} onChange={e => setFrequency(e.target.value as any)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900">
+            <option value="once">Una vez</option>
+            <option value="daily">Diario</option>
+            <option value="weekly">Semanal</option>
+            <option value="monthly">Mensual</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-slate-500">Ocurrencias (opcional)</span>
+          <input type="number" min={1} max={100} value={occ} onChange={e => setOcc(e.target.value ? Number(e.target.value) : "")} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900" />
+        </label>
+      </div>
+
+      <div className="flex gap-2">
+        <button className="px-4 py-2 rounded-xl bg-blue-600 text-white">Asignar</button>
+      </div>
+    </form>
+  );
+}
+
+function PatientPicker({ onPick }: { onPick: (id: string) => void }) {
+  // Reutilizamos QuickBar pero interceptamos navegación
+  // Truco: sobrescribimos router.push de QuickBar vía location mock? Simpler: envolvemos QuickBar y escuchamos click → para demo pedimos id manual.
+  // Para no tocar QuickBar original, ofrecemos un input rápido:
+  const [id, setId] = React.useState("");
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1">
+        <QuickBar placeholder="Buscar paciente…" />
+      </div>
+      <input className="rounded-xl border px-3 py-2 w-[16rem]" placeholder="o pega Patient ID" value={id} onChange={e => setId(e.target.value)} />
+      <button type="button" onClick={() => id && onPick(id)} className="px-3 py-2 rounded-lg border">Usar ID</button>
+    </div>
+  );
+}

--- a/components/work/PatientAssignments.tsx
+++ b/components/work/PatientAssignments.tsx
@@ -1,0 +1,57 @@
+// components/work/PatientAssignments.tsx
+"use client";
+
+import * as React from "react";
+import { listAssignments, logEvent, patchAssignment, type WorkAssignment } from "@/lib/work/assignments";
+import { getActiveOrg } from "@/lib/org-local";
+import ColorEmoji from "@/components/ColorEmoji";
+
+export default function PatientAssignments({ patientId }: { patientId: string }) {
+  const org = getActiveOrg();
+  const [items, setItems] = React.useState<WorkAssignment[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  async function load() {
+    if (!org.id) return;
+    setLoading(true);
+    const res = await listAssignments({ org_id: org.id, patient_id: patientId, limit: 100 });
+    setItems(res.items ?? []);
+    setLoading(false);
+  }
+  React.useEffect(() => { load(); /* eslint-disable-next-line */ }, [org.id, patientId]);
+
+  async function complete(a: WorkAssignment) {
+    const res = await logEvent({ org_id: a.org_id, assignment_id: a.id, kind: "completed" });
+    if (res?.ok) await load();
+  }
+  async function pause(a: WorkAssignment) {
+    const res = await patchAssignment(a.id, { status: a.status === "paused" ? "active" : "paused" });
+    if (res?.ok) await load();
+  }
+
+  return (
+    <div className="rounded-2xl border bg-white/95 dark:bg-slate-900/60">
+      <div className="p-4 flex items-center justify-between">
+        <h3 className="font-semibold flex items-center gap-2"><ColorEmoji token="trabajo" /> Tareas asignadas</h3>
+        {loading && <span className="text-sm text-slate-500">Cargando…</span>}
+      </div>
+      <ul className="divide-y">
+        {items.map(a => (
+          <li key={a.id} className="p-4 flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <div className="font-medium truncate">{a.title}</div>
+              <div className="text-xs text-slate-500 truncate">
+                {a.module} · {a.status} {a.due_at ? ` · vence ${new Date(a.due_at).toLocaleString()}` : ""} {a.last_done_at ? ` · última ${new Date(a.last_done_at).toLocaleString()}` : ""}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button className="px-3 py-2 rounded-lg border" onClick={() => pause(a)}>{a.status === "paused" ? "Reanudar" : "Pausar"}</button>
+              <button className="px-3 py-2 rounded-lg bg-emerald-600 text-white" onClick={() => complete(a)}>Marcar completada</button>
+            </div>
+          </li>
+        ))}
+        {items.length === 0 && !loading && <li className="p-4 text-sm text-slate-500">Sin asignaciones</li>}
+      </ul>
+    </div>
+  );
+}

--- a/components/work/TemplateEditor.tsx
+++ b/components/work/TemplateEditor.tsx
@@ -1,0 +1,96 @@
+// components/work/TemplateEditor.tsx
+"use client";
+
+import * as React from "react";
+import { listTemplates, createTemplate, updateTemplate, type WorkTemplate } from "@/lib/work/templates";
+import { getActiveOrg } from "@/lib/org-local";
+import ColorEmoji from "@/components/ColorEmoji";
+
+const MODULES = ["general", "mente", "equilibrio", "sonrisa", "pulso"] as const;
+
+export default function TemplateEditor() {
+  const org = getActiveOrg();
+  const [module, setModule] = React.useState<(typeof MODULES)[number]>("general");
+  const [title, setTitle] = React.useState("");
+  const [content, setContent] = React.useState("{}");
+  const [tags, setTags] = React.useState<string>("");
+  const [list, setList] = React.useState<WorkTemplate[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  async function load() {
+    if (!org.id) return;
+    setLoading(true);
+    const res = await listTemplates({ org_id: org.id, module });
+    setList(res);
+    setLoading(false);
+  }
+
+  React.useEffect(() => { load(); /* eslint-disable-next-line */ }, [module, org.id]);
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!org.id) return;
+    let json: any = {};
+    try { json = JSON.parse(content || "{}"); } catch { alert("JSON inválido en contenido"); return; }
+    const res = await createTemplate({ org_id: org.id, module, title, content: json, tags: tags.split(",").map(s => s.trim()).filter(Boolean), is_active: true });
+    if (res?.ok) { setTitle(""); setContent("{}"); setTags(""); await load(); }
+    else alert(res?.error?.message || "Error al crear");
+  }
+
+  async function toggleActive(t: WorkTemplate) {
+    const res = await updateTemplate(t.id, { is_active: !t.is_active });
+    if (res?.ok) await load();
+  }
+
+  return (
+    <div className="space-y-8">
+      <form onSubmit={onCreate} className="rounded-2xl border bg-white/95 dark:bg-slate-900/60 p-4 space-y-3">
+        <h3 className="font-semibold flex items-center gap-2"><ColorEmoji token="carpeta" /> Nueva plantilla</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-sm text-slate-500">Módulo</span>
+            <select value={module} onChange={e => setModule(e.target.value as any)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900">
+              {MODULES.map(m => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 md:col-span-2">
+            <span className="text-sm text-slate-500">Título</span>
+            <input value={title} onChange={e => setTitle(e.target.value)} required className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900" />
+          </label>
+          <label className="flex flex-col gap-1 md:col-span-3">
+            <span className="text-sm text-slate-500">Contenido (JSON)</span>
+            <textarea value={content} onChange={e => setContent(e.target.value)} rows={6} className="rounded-xl border px-3 py-2 font-mono text-xs bg-white dark:bg-slate-900" />
+          </label>
+          <label className="flex flex-col gap-1 md:col-span-3">
+            <span className="text-sm text-slate-500">Tags (coma)</span>
+            <input value={tags} onChange={e => setTags(e.target.value)} className="rounded-xl border px-3 py-2 bg-white dark:bg-slate-900" />
+          </label>
+        </div>
+        <div className="flex gap-2">
+          <button className="px-4 py-2 rounded-xl bg-blue-600 text-white">Guardar plantilla</button>
+        </div>
+      </form>
+
+      <div className="rounded-2xl border bg-white/95 dark:bg-slate-900/60">
+        <div className="p-4 flex items-center justify-between">
+          <h3 className="font-semibold flex items-center gap-2"><ColorEmoji token="carpeta" /> Plantillas ({module})</h3>
+          {loading && <span className="text-sm text-slate-500">Cargando…</span>}
+        </div>
+        <ul className="divide-y">
+          {list.map(t => (
+            <li key={t.id} className="p-4 flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <div className="font-medium truncate">{t.title}</div>
+                <div className="text-xs text-slate-500 truncate">Tags: {t.tags?.join(", ") || "—"}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button onClick={() => toggleActive(t)} className="px-3 py-1 rounded-lg border">{t.is_active ? "Desactivar" : "Activar"}</button>
+              </div>
+            </li>
+          ))}
+          {list.length === 0 && !loading && <li className="p-4 text-sm text-slate-500">Sin plantillas</li>}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/lib/http/validate.ts
+++ b/lib/http/validate.ts
@@ -1,0 +1,38 @@
+// lib/http/validate.ts
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export function jsonOk<T = any>(data: T, init?: number | ResponseInit) {
+  return NextResponse.json({ ok: true, data }, typeof init === "number" ? { status: init } : init);
+}
+export function jsonError(code: string, message: string, status = 400) {
+  return NextResponse.json({ ok: false, error: { code, message } }, { status });
+}
+
+export async function parseJson(req: NextRequest) {
+  try {
+    return await req.json();
+  } catch {
+    return {};
+  }
+}
+export function parseOrError<T>(schema: z.Schema<T>, data: any): { ok: true; data: T } | { ok: false; error: { code: string; message: string } } {
+  const res = schema.safeParse(data);
+  if (res.success) return { ok: true, data: res.data };
+  const msg = res.error.issues.map(i => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+  return { ok: false, error: { code: "VALIDATION_ERROR", message: msg } };
+}
+
+export function requireHeader(req: NextRequest, name: string, expected?: string | null) {
+  const v = req.headers.get(name);
+  if (!v) return { ok: false, error: { code: "UNAUTHORIZED", message: `Missing header ${name}` } };
+  if (expected && v !== expected) return { ok: false, error: { code: "UNAUTHORIZED", message: `Bad ${name}` } };
+  return { ok: true, value: v };
+}
+
+export function readOrgIdFromQuery(req: NextRequest) {
+  const qp = new URL(req.url).searchParams;
+  const org_id = qp.get("org_id") ?? undefined;
+  if (!org_id) return { ok: false as const, error: { code: "BAD_REQUEST", message: "Falta org_id" } };
+  return { ok: true as const, org_id };
+}

--- a/lib/work/assignments.ts
+++ b/lib/work/assignments.ts
@@ -1,0 +1,58 @@
+// lib/work/assignments.ts
+export type WorkAssignment = {
+  id: string;
+  org_id: string;
+  patient_id: string;
+  provider_id: string;
+  module: "mente" | "equilibrio" | "sonrisa" | "pulso" | "general";
+  template_id: string | null;
+  title: string;
+  content: any;
+  due_at: string | null;
+  frequency: "once" | "daily" | "weekly" | "monthly";
+  occurrences: number | null;
+  notes: string | null;
+  status: "active" | "paused" | "completed" | "canceled";
+  last_done_at: string | null;
+  created_at?: string;
+};
+
+export async function listAssignments(params: { org_id: string; patient_id?: string; module?: WorkAssignment["module"]; status?: WorkAssignment["status"]; page?: number; limit?: number }) {
+  const url = new URL("/api/work/assignments", window.location.origin);
+  url.searchParams.set("org_id", params.org_id);
+  if (params.patient_id) url.searchParams.set("patient_id", params.patient_id);
+  if (params.module) url.searchParams.set("module", params.module);
+  if (params.status) url.searchParams.set("status", params.status);
+  if (params.page) url.searchParams.set("page", String(params.page));
+  if (params.limit) url.searchParams.set("limit", String(params.limit));
+  const r = await fetch(url.toString(), { cache: "no-store" });
+  const j = await r.json();
+  return j?.ok ? j.data : { items: [], meta: { page: 1, pageSize: 50, total: 0 } };
+}
+
+export async function assignWork(input: {
+  org_id: string;
+  patient_ids: string[];
+  provider_id?: string;
+  module: WorkAssignment["module"];
+  template_id?: string;
+  title?: string;
+  content?: any;
+  due_at?: string;
+  frequency?: WorkAssignment["frequency"];
+  occurrences?: number;
+  notes?: string;
+}) {
+  const r = await fetch("/api/work/assign", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input) });
+  return await r.json();
+}
+
+export async function logEvent(input: { org_id: string; assignment_id: string; kind: "completed" | "note" | "skipped"; payload?: any }) {
+  const r = await fetch("/api/work/events", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input) });
+  return await r.json();
+}
+
+export async function patchAssignment(id: string, patch: Partial<Pick<WorkAssignment, "title" | "content" | "due_at" | "status" | "notes">>) {
+  const r = await fetch(`/api/work/assignments/${id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(patch) });
+  return await r.json();
+}

--- a/lib/work/templates.ts
+++ b/lib/work/templates.ts
@@ -1,0 +1,35 @@
+// lib/work/templates.ts
+export type WorkTemplate = {
+  id: string;
+  org_id: string;
+  module: "mente" | "equilibrio" | "sonrisa" | "pulso" | "general";
+  title: string;
+  content: any;
+  tags: string[];
+  is_active: boolean;
+  created_by?: string | null;
+  created_at?: string;
+};
+
+export async function listTemplates(params: { org_id: string; module?: WorkTemplate["module"]; q?: string; active?: boolean }) {
+  const url = new URL("/api/work/templates", window.location.origin);
+  url.searchParams.set("org_id", params.org_id);
+  if (params.module) url.searchParams.set("module", params.module);
+  if (params.q) url.searchParams.set("q", params.q);
+  if (typeof params.active === "boolean") url.searchParams.set("active", String(params.active));
+  const r = await fetch(url.toString(), { cache: "no-store" });
+  const j = await r.json();
+  return j?.ok ? (j.data as WorkTemplate[]) : [];
+}
+
+export async function createTemplate(input: Omit<WorkTemplate, "id" | "created_at" | "created_by">) {
+  const r = await fetch("/api/work/templates", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input) });
+  const j = await r.json();
+  return j;
+}
+
+export async function updateTemplate(id: string, patch: Partial<Pick<WorkTemplate, "title" | "content" | "tags" | "is_active">>) {
+  const r = await fetch(`/api/work/templates/${id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(patch) });
+  const j = await r.json();
+  return j;
+}


### PR DESCRIPTION
## Summary
- add shared HTTP helpers for consistent JSON responses and validation handling
- implement Supabase-backed API routes for templates, assignments, and work events
- build client helpers and pages to manage templates and assign tasks to patients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db57fd3388832ab136ac4851237a63