### PR TITLE
feat: add consultorio hub and pro areas pages

### DIFF
--- a/app/(app)/ajustes/page.tsx
+++ b/app/(app)/ajustes/page.tsx
@@ -1,0 +1,43 @@
+// app/(app)/ajustes/page.tsx
+"use client";
+
+import * as React from "react";
+import AccentHeader from "@/components/ui/AccentHeader";
+import ThemeToggle from "@/components/ThemeToggle";
+import Link from "next/link";
+import ColorEmoji from "@/components/ColorEmoji";
+
+export default function AjustesPage() {
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader
+        title="Ajustes"
+        subtitle="Preferencias de cuenta y personalización."
+        emojiToken="ajustes"
+      />
+
+      <section className="rounded-3xl bg-white/95 border p-6 space-y-4">
+        <h3 className="font-semibold">Apariencia</h3>
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
+          <span className="text-sm text-slate-600">Activa/desactiva modo oscuro.</span>
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-white/95 border p-6 space-y-3">
+        <h3 className="font-semibold">Cuenta</h3>
+        <div className="grid md:grid-cols-2 gap-3">
+          <Link href="/perfil" className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border">
+            <ColorEmoji token="perfil" /> Editar perfil
+          </Link>
+          <Link href="/banco" className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border">
+            <ColorEmoji token="banco" /> Pagos y suscripciones
+          </Link>
+          <Link href="/profesionales" className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border">
+            <ColorEmoji token="megafono" /> Ver perfil público
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(app)/areas/page.tsx
+++ b/app/(app)/areas/page.tsx
@@ -1,0 +1,58 @@
+// app/(app)/areas/page.tsx
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import AccentHeader from "@/components/ui/AccentHeader";
+import ColorEmoji from "@/components/ColorEmoji";
+
+type Area = { href: string; name: string; desc: string; token: string; };
+
+const AREAS: Area[] = [
+  { href: "/modulos/mente", name: "Mente", desc: "Evaluaciones, escalas y planes de apoyo.", token: "mente" },
+  { href: "/modulos/pulso", name: "Pulso", desc: "Indicadores clínicos, semáforos y riesgo CV.", token: "pulso" },
+  { href: "/modulos/equilibrio", name: "Equilibrio", desc: "Planes de hábitos y seguimiento.", token: "equilibrio" },
+  { href: "/modulos/sonrisa", name: "Sonrisa", desc: "Odontograma, presupuestos y firma.", token: "sonrisa" },
+];
+
+export default function AreasProPage() {
+  // En un futuro: consultar /api/billing/subscription/status para mostrar estado real.
+  const hasPro = false;
+
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader
+        title="Áreas Pro"
+        subtitle="Especialidades con herramientas avanzadas. Desbloquea desde Sanoa Bank."
+        emojiToken="carpeta"
+      />
+
+      <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        {AREAS.map((a) => (
+          <div key={a.href} className="relative rounded-3xl border bg-white/95 p-6">
+            <div className="flex gap-3">
+              <div className="h-12 w-12 rounded-2xl border inline-grid place-content-center">
+                <ColorEmoji token={a.token} />
+              </div>
+              <div>
+                <h3 className="font-semibold">{a.name} <span className="ml-2 text-xs px-2 py-0.5 rounded-full bg-violet-100 text-violet-800 border border-violet-300">Pro</span></h3>
+                <p className="text-sm text-slate-600">{a.desc}</p>
+              </div>
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <Link href={a.href} className="px-3 py-2 rounded-xl border">Ver módulo</Link>
+              {!hasPro && (
+                <Link href="/banco" className="px-3 py-2 rounded-xl bg-amber-500 text-white">Desbloquear con Sanoa Bank</Link>
+              )}
+            </div>
+
+            {!hasPro && (
+              <div className="absolute inset-0 rounded-3xl bg-white/50 backdrop-blur-[1px] pointer-events-none" aria-hidden />
+            )}
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/app/(app)/consultorio/page.tsx
+++ b/app/(app)/consultorio/page.tsx
@@ -1,0 +1,114 @@
+// app/(app)/consultorio/page.tsx
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import AccentHeader from "@/components/ui/AccentHeader";
+import ColorEmoji from "@/components/ColorEmoji";
+import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
+import { getActiveOrg } from "@/lib/org-local";
+
+type MiniOverview = {
+  nextAppointments: number;
+  activePatients: number;
+  monthIncomeMXN: number;
+};
+
+export default function ConsultorioPage() {
+  const org = getActiveOrg();
+  const [mini, setMini] = React.useState<MiniOverview | null>(null);
+
+  React.useEffect(() => {
+    (async () => {
+      // Best-effort: si falla, dejamos los números en null
+      try {
+        const r = await fetch("/api/reports/overview", { cache: "no-store" });
+        const j = await r.json();
+        if (j?.ok) {
+          setMini({
+            nextAppointments: j.data?.nextAppointments ?? 0,
+            activePatients: j.data?.activePatients ?? 0,
+            monthIncomeMXN: j.data?.monthIncomeMXN ?? 0,
+          });
+        }
+      } catch {
+        /* noop */
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="p-6 md:p-10 space-y-8">
+      <AccentHeader
+        title="Mi Consultorio"
+        subtitle="Tu centro operativo: agenda, pacientes, recetas, laboratorio, recordatorios."
+        emojiToken="tablero"
+      />
+
+      {/* Buscador rápido de pacientes */}
+      <section className="rounded-3xl bg-white/95 border p-6">
+        <h3 className="font-semibold">Buscar paciente</h3>
+        <div className="mt-3 max-w-xl">
+          <PatientAutocomplete
+            orgId={org.id ?? ""}
+            scope="org"
+            placeholder="Escribe nombre del paciente…"
+            onSelect={(hit) => {
+              if (hit) window.location.href = `/pacientes/${hit.id}`;
+            }}
+          />
+        </div>
+        <p className="text-xs text-slate-500 mt-2">Solo aparecen pacientes de tu organización (RLS).</p>
+      </section>
+
+      {/* Tarjetas operativas */}
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <CardLink href="/agenda" token="agenda" title="Agenda" desc="Citas, disponibilidad y confirmaciones." />
+        <CardLink href="/pacientes" token="pacientes" title="Pacientes" desc="Listado, filtros, etiquetas y timeline." />
+        <CardLink href="/prescriptions/templates" token="recetas" title="Recetas" desc="Plantillas y emisión con membrete." />
+        <CardLink href="/laboratorio" token="laboratorio" title="Laboratorio" desc="Órdenes y resultados con firma." />
+        <CardLink href="/recordatorios" token="recordatorios" title="Recordatorios" desc="Mensajes SMS/WhatsApp programados." />
+        <CardLink href="/reportes" token="reportes" title="Reportes" desc="Indicadores operativos y clínicos." />
+      </section>
+
+      {/* Mini-métricas */}
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Stat title="Próximas citas (7 días)" value={mini?.nextAppointments ?? "—"} />
+        <Stat title="Pacientes activos" value={mini?.activePatients ?? "—"} />
+        <Stat title="Ingresos del mes" value={
+          typeof mini?.monthIncomeMXN === "number"
+            ? mini!.monthIncomeMXN.toLocaleString("es-MX", { style: "currency", currency: "MXN" })
+            : "—"
+        } />
+      </section>
+    </main>
+  );
+}
+
+function CardLink({ href, token, title, desc }:{
+  href: string; token: string; title: string; desc: string;
+}) {
+  return (
+    <Link href={href} className="group rounded-3xl border bg-white/95 p-6 hover:shadow transition block">
+      <div className="flex gap-3">
+        <div className="h-12 w-12 rounded-2xl border inline-grid place-content-center">
+          <ColorEmoji token={token} />
+        </div>
+        <div>
+          <h3 className="font-semibold">{title}</h3>
+          <p className="text-sm text-slate-600">{desc}</p>
+        </div>
+      </div>
+      <div className="mt-4 text-sm text-blue-600">Abrir →</div>
+    </Link>
+  );
+}
+
+function Stat({ title, value }:{ title: string; value: number | string }) {
+  return (
+    <div className="rounded-3xl border bg-white/95 p-6">
+      <p className="text-sm text-slate-600">{title}</p>
+      <p className="mt-2 text-3xl tracking-tight">{value}</p>
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import ColorEmoji from "@/components/ColorEmoji";
 import { getSupabaseBrowser } from "@/lib/supabase-browser";
 import { useToastSafe } from "@/components/Toast";
@@ -11,23 +11,11 @@ import { useToastSafe } from "@/components/Toast";
 type NavItem = { href: string; label: string; token: string };
 
 const NAV: NavItem[] = [
-  { href: "/dashboard", label: "Tablero", token: "tablero" },
-  { href: "/agenda", label: "Agenda", token: "agenda" },
-  { href: "/pacientes", label: "Pacientes", token: "pacientes" },
-  { href: "/laboratorio", label: "Laboratorio", token: "laboratorio" },
-  { href: "/modulos", label: "Módulos", token: "carpeta" },
-  { href: "/recordatorios", label: "Recordatorios", token: "recordatorios" },
-  { href: "/reportes", label: "Reportes", token: "reportes" },
+  { href: "/consultorio", label: "Consultorio", token: "tablero" },
+  { href: "/areas", label: "Áreas Pro", token: "carpeta" },
   { href: "/banco", label: "Banco", token: "banco" },
-  { href: "/ajustes/plan", label: "Plan", token: "plan" },
-];
-
-// Subnavegación contextual para Banco
-const BANK_NAV: { href: string; label: string }[] = [
-  { href: "/banco", label: "Resumen" },
-  { href: "/banco/tx", label: "Transacciones" },
-  { href: "/banco/reglas", label: "Reglas" },
-  { href: "/banco/presupuestos", label: "Presupuestos" },
+  { href: "/perfil", label: "Perfil", token: "perfil" },
+  { href: "/ajustes", label: "Ajustes", token: "ajustes" },
 ];
 
 export default function Navbar() {
@@ -36,15 +24,6 @@ export default function Navbar() {
   const supabase = getSupabaseBrowser();
   const { toast } = useToastSafe();
   const [signingOut, setSigningOut] = useState(false);
-
-  const isBank = useMemo(
-    () => pathname === "/banco" || pathname.startsWith("/banco/"),
-    [pathname]
-  );
-
-  function isActive(href: string) {
-    return pathname === href || (href !== "/dashboard" && pathname.startsWith(href + "/"));
-  }
 
   async function handleSignOut() {
     setSigningOut(true);
@@ -70,10 +49,9 @@ export default function Navbar() {
 
   return (
     <header className="sticky top-0 z-40 border-b border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
-      {/* Barra principal */}
       <div className="mx-auto max-w-6xl px-4 h-16 flex items-center justify-between gap-4">
         {/* Brand */}
-        <Link href="/dashboard" className="inline-flex items-center gap-2" aria-label="Ir al tablero">
+        <Link href="/consultorio" className="inline-flex items-center gap-2" aria-label="Ir a Consultorio">
           <span className="inline-grid place-content-center h-9 w-9 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
             <ColorEmoji token="logo" />
           </span>
@@ -81,18 +59,19 @@ export default function Navbar() {
         </Link>
 
         {/* Nav */}
-        <nav className="hidden md:flex items-center gap-1" aria-label="Navegación principal">
+        <nav className="hidden md:flex items-center gap-1">
           {NAV.map((item) => {
-            const active = isActive(item.href);
+            const isActive =
+              pathname === item.href || (item.href !== "/consultorio" && pathname.startsWith(item.href + "/"));
             return (
               <Link
                 key={item.href}
                 href={item.href}
-                aria-current={active ? "page" : undefined}
+                aria-current={isActive ? "page" : undefined}
                 className={[
                   "inline-flex items-center gap-2 px-3 py-2 rounded-lg border transition",
                   "text-slate-700 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-white/10",
-                  active ? "bg-white dark:bg-white/10 border-slate-200 dark:border-slate-700" : "border-transparent",
+                  isActive ? "bg-white dark:bg-white/10 border-slate-200 dark:border-slate-700" : "border-transparent",
                 ].join(" ")}
               >
                 <ColorEmoji token={item.token} />
@@ -115,32 +94,6 @@ export default function Navbar() {
           </button>
         </div>
       </div>
-
-      {/* Subnavegación contextual: Banco */}
-      {isBank && (
-        <div className="border-t border-slate-200 dark:border-slate-700">
-          <div className="mx-auto max-w-6xl px-4 h-12 flex items-center gap-2 overflow-x-auto" aria-label="Navegación de Banco">
-            {BANK_NAV.map((it) => {
-              const active = pathname === it.href || pathname.startsWith(it.href + "/");
-              return (
-                <Link
-                  key={it.href}
-                  href={it.href}
-                  aria-current={active ? "page" : undefined}
-                  className={[
-                    "inline-flex items-center px-3 py-1.5 rounded-lg border text-sm transition",
-                    active
-                      ? "bg-white dark:bg-white/10 border-slate-200 dark:border-slate-700 text-slate-900 dark:text-white"
-                      : "border-transparent text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/10",
-                  ].join(" ")}
-                >
-                  {it.label}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      )}
     </header>
   );
 }

--- a/lib/http/validate.ts
+++ b/lib/http/validate.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ZodSchema, ZodError } from "zod";
+
+/** Respuesta de éxito consistente */
+export function jsonOk<T = unknown>(data?: T, meta?: Record<string, unknown>) {
+  return NextResponse.json({ ok: true, data: data ?? null, meta: meta ?? undefined });
+}
+
+/** Respuesta de error consistente */
+export function jsonError(code: string, message: string, status = 400, extra?: Record<string, unknown>) {
+  return NextResponse.json({ ok: false, error: { code, message, ...(extra || {}) } }, { status });
+}
+
+/** Lee JSON con control de errores */
+export async function parseJson<T = unknown>(req: NextRequest): Promise<T | null> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Valida contra un ZodSchema devolviendo estructura {ok, data|error} */
+export function parseOrError<T>(schema: ZodSchema<T>, value: unknown):
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string; issues?: string[] } } {
+  try {
+    const data = schema.parse(value);
+    return { ok: true, data };
+  } catch (e) {
+    const issues =
+      e instanceof ZodError ? e.issues.map((i) => `${i.path.join(".")}: ${i.message}`) : ["Invalid payload"];
+    return { ok: false, error: { code: "VALIDATION_ERROR", message: issues.join("; "), issues } };
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable HTTP helpers for consistent API validation responses
- refresh the navbar to highlight consultorio, areas pro, perfil, and ajustes
- create consultorio, areas pro, and ajustes landing pages with quick actions

## Testing
- pnpm lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68db5ef68210832a835c7130e4ce12ca