### PR TITLE
Add agreements aliases, bank checkout endpoint, and Areas Pro page

### DIFF
--- a/app/(app)/especialidades/page.tsx
+++ b/app/(app)/especialidades/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import Link from "next/link";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const areas = [
+  { href: "/modulos/mente", emoji: "🧠", title: "Mente", desc: "Evaluaciones, sesiones, timeline" },
+  { href: "/modulos/pulso", emoji: "💓", title: "Pulso", desc: "Signos, metas y seguimiento" },
+  { href: "/modulos/equilibrio", emoji: "⚖️", title: "Equilibrio", desc: "Hábitos, planes y progreso" },
+  { href: "/modulos/sonrisa", emoji: "😄", title: "Sonrisa", desc: "Odontograma, presupuestos" },
+];
+
+export default function AreasProPage() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6">
+      <h1 className="text-3xl font-semibold mb-6">Áreas Pro</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        {areas.map((a) => (
+          <Card key={a.href} className="glass p-5 hover:scale-[1.01] transition">
+            <div className="text-4xl mb-3">{a.emoji}</div>
+            <h2 className="text-xl font-medium">{a.title}</h2>
+            <p className="text-sm opacity-80 mb-4">{a.desc}</p>
+            <div className="flex gap-2">
+              <Link href={a.href} className="grow">
+                <Button className="w-full glass-btn" type="button">
+                  🚀 Abrir (Vista previa)
+                </Button>
+              </Link>
+              <Link href={`/banco?sku=${encodeURIComponent("areas-pro.destacado")}`}>
+                <Button variant="outline" className="glass-btn">💳 Desbloquear</Button>
+              </Link>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/api/acuerdos/accept/route.ts
+++ b/app/api/acuerdos/accept/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const { agreement_id, accepted_by = "patient" } = body ?? {};
+  if (!agreement_id) return NextResponse.json({ error: "agreement_id requerido" }, { status: 400 });
+
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("agreements")
+    .update({ accepted_by, accepted_at: new Date().toISOString() })
+    .eq("id", agreement_id)
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true, agreement: data }, { status: 200 });
+}

--- a/app/api/acuerdos/create/route.ts
+++ b/app/api/acuerdos/create/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const { contract_type = "specialist_patient", org_id = null, subject_id = null, subject_type = null, version = "1.0.0" } = body ?? {};
+
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("agreements")
+    .insert([{ contract_type, org_id, subject_id, subject_type, version }])
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true, agreement: data }, { status: 200 });
+}

--- a/app/api/bank/checkout/route.ts
+++ b/app/api/bank/checkout/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { stripe } from "@/lib/billing/stripe";
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const { sku, org_id, success_url = `${process.env.NEXT_PUBLIC_SITE_URL}/banco?ok=1`, cancel_url = `${process.env.NEXT_PUBLIC_SITE_URL}/banco?c=1` } = body ?? {};
+  if (!sku || !org_id) return NextResponse.json({ error: "sku y org_id requeridos" }, { status: 400 });
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      line_items: [{ price: sku, quantity: 1 }],
+      allow_promotion_codes: true,
+      metadata: { org_id },
+      success_url,
+      cancel_url
+    });
+    return NextResponse.json({ ok: true, url: session.url }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -352,3 +352,40 @@ button {
 .tile-btn--danger:hover {
   background: #ffe4e6;
 }
+
+:root {
+  --scale: 1.06; /* sube todo ~6% */
+}
+
+html { font-size: calc(16px * var(--scale)); }
+* { -webkit-tap-highlight-color: transparent; }
+
+.glass {
+  background: var(--card-bg, rgba(255,255,255,0.14));
+  background: linear-gradient(180deg, rgba(255,255,255,0.10), rgba(255,255,255,0.06));
+  border: 1px solid rgba(255,255,255,0.18);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  backdrop-filter: blur(10px);
+  border-radius: 1rem;
+}
+
+.dark .glass {
+  background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.04));
+  border-color: rgba(255,255,255,0.12);
+}
+
+.glass-btn {
+  background: rgba(255,255,255,0.14);
+  border: 1px solid rgba(255,255,255,0.18);
+  backdrop-filter: blur(8px);
+}
+
+.dark .glass-btn {
+  background: rgba(255,255,255,0.10);
+  border-color: rgba(255,255,255,0.12);
+}
+
+/* Mejor contraste en dark dentro de tarjetas */
+.dark .glass, .dark .glass * {
+  color: rgba(255,255,255,0.92);
+}

--- a/components/EmojiIcon.tsx
+++ b/components/EmojiIcon.tsx
@@ -1,0 +1,12 @@
+"use client";
+import Link from "next/link";
+
+export default function EmojiIcon({
+  emoji,
+  href,
+  size = "text-2xl",
+  title,
+}: { emoji: string; href?: string; size?: string; title?: string }) {
+  const node = <span className={`${size} leading-none`} aria-label={title}>{emoji}</span>;
+  return href ? <Link href={href} className="inline-flex items-center">{node}</Link> : node;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,17 +5,18 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import ColorEmoji from "@/components/ColorEmoji";
+import EmojiIcon from "@/components/EmojiIcon";
 import { getSupabaseBrowser } from "@/lib/supabase-browser";
 import { useToastSafe } from "@/components/Toast";
 
-type NavItem = { href: string; label: string; token: string };
+type NavItem = { href: string; label: string; token: string; emoji: string };
 
 const NAV: NavItem[] = [
-  { href: "/consultorio", label: "Consultorio", token: "tablero" },
-  { href: "/areas", label: "Áreas Pro", token: "carpeta" },
-  { href: "/banco", label: "Banco", token: "banco" },
-  { href: "/perfil", label: "Perfil", token: "perfil" },
-  { href: "/ajustes", label: "Ajustes", token: "ajustes" },
+  { href: "/consultorio", label: "Consultorio", token: "tablero", emoji: "🩺" },
+  { href: "/areas", label: "Áreas Pro", token: "carpeta", emoji: "🗂️" },
+  { href: "/banco", label: "Banco", token: "banco", emoji: "🏦" },
+  { href: "/perfil", label: "Perfil", token: "perfil", emoji: "🙂" },
+  { href: "/ajustes", label: "Ajustes", token: "ajustes", emoji: "⚙️" },
 ];
 
 export default function Navbar() {
@@ -63,7 +64,7 @@ export default function Navbar() {
         </Link>
 
         {/* Nav */}
-        <nav className="hidden md:flex items-center gap-1">
+        <nav className="hidden md:flex items-center gap-1 text-[17px]">
           {NAV.map((item) => {
             const isActive =
               pathname === item.href ||
@@ -74,15 +75,15 @@ export default function Navbar() {
                 href={item.href}
                 aria-current={isActive ? "page" : undefined}
                 className={[
-                  "inline-flex items-center gap-2 px-3 py-2 rounded-lg border transition",
+                  "inline-flex items-center gap-3 px-3 py-3 rounded-lg border transition",
                   "text-slate-700 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-white/10",
                   isActive
                     ? "bg-white dark:bg-white/10 border-slate-200 dark:border-slate-700"
                     : "border-transparent",
                 ].join(" ")}
               >
-                <ColorEmoji token={item.token} />
-                <span className="font-medium">{item.label}</span>
+                <EmojiIcon emoji={item.emoji} title={item.label} />
+                <span className="font-medium text-[17px]">{item.label}</span>
               </Link>
             );
           })}
@@ -93,7 +94,7 @@ export default function Navbar() {
           <button
             onClick={handleSignOut}
             disabled={signingOut}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-rose-500 text-white hover:brightness-95 active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed transition"
+            className="inline-flex items-center gap-2 px-3 py-3 rounded-xl bg-rose-500 text-white text-[17px] hover:brightness-95 active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed transition"
             title="Cerrar sesión"
           >
             <ColorEmoji token="desbloquear" />

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "glass flex flex-col gap-6 rounded-xl border border-transparent p-4 shadow-sm",
         className,
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("font-semibold leading-none", className)}
       {...props}
     />
   );
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,31 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Contraste mejor en dark
+        bg: {
+          DEFAULT: "#0b0f14",
+          glass: "rgba(255,255,255,0.06)",
+          border: "rgba(255,255,255,0.14)",
+        },
+        fg: {
+          DEFAULT: "#0d1218",
+          glass: "rgba(13,18,24,0.5)",
+          border: "rgba(255,255,255,0.08)",
+        }
+      },
+      backdropBlur: {
+        xs: "2px",
+      }
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- add Spanish alias API endpoints for creating and accepting agreements
- provide a bank checkout API backed by Stripe subscriptions
- introduce the Áreas Pro page and refresh shared UI styles including glass cards, Tailwind config, navbar, and emoji icon helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc18ca4640832ab0f9ee56e65a7d89