### PR TITLE
Improve bank org gating UX

### DIFF
--- a/app/(app)/banco/reglas/page.tsx
+++ b/app/(app)/banco/reglas/page.tsx
@@ -1,21 +1,55 @@
 "use client";
 
-import { useMemo } from "react";
-import { getActiveOrg } from "@/lib/org-local";
+import Link from "next/link";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
 import RulesEditor from "@/components/bank/RulesEditor";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
 
 export default function BankRulesPage() {
-  const org = useMemo(() => getActiveOrg(), []);
-  const orgId = org?.id || "";
+  const { orgId, isLoading } = useBankActiveOrg();
+
+  if (isLoading) {
+    return (
+      <div className="p-4 md:p-6 max-w-6xl mx-auto">
+        <div className="glass-card p-6 max-w-md">
+          <h1 className="text-lg font-semibold mb-2">
+            <span className="emoji">🏦</span> Sanoa Bank
+          </h1>
+          <p className="text-sm text-slate-600">Cargando organizaciones…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!orgId) {
+    return (
+      <div className="p-4 md:p-6 max-w-6xl mx-auto">
+        <div className="glass-card p-6 max-w-md">
+          <h1 className="text-lg font-semibold mb-2">
+            <span className="emoji">🏦</span> Sanoa Bank
+          </h1>
+          <p className="mb-4">Selecciona una organización activa para continuar.</p>
+          <div className="flex flex-col gap-3">
+            <OrgSwitcherBadge variant="inline" />
+            <Link
+              href="/organizaciones"
+              className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+            >
+              Administrar organizaciones
+            </Link>
+            <p className="text-xs text-slate-500">
+              Tip: también puedes cambiar de organización desde la esquina superior derecha.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="p-4 md:p-6 max-w-6xl mx-auto">
       <h1 className="text-2xl font-semibold mb-2">Banco · Reglas</h1>
-      {!orgId && (
-        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3 mb-4">
-          Selecciona una organización activa para continuar.
-        </p>
-      )}
-      {orgId && <RulesEditor />}
+      <RulesEditor />
     </div>
   );
 }

--- a/app/(app)/banco/tx/page.tsx
+++ b/app/(app)/banco/tx/page.tsx
@@ -1,20 +1,57 @@
 "use client";
 
-import { useMemo } from "react";
+import Link from "next/link";
 import TxFilters from "@/components/bank/TxFilters";
 import TxTable from "@/components/bank/TxTable";
 import SavedViewsBar from "@/components/saved-views/SavedViewsBar";
 import { useSearchParams } from "next/navigation";
-import { getActiveOrg } from "@/lib/org-local";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
 
 export default function BankTxPage() {
-  const org = useMemo(() => getActiveOrg(), []);
-  const orgId = org?.id || "";
+  const { orgId, isLoading } = useBankActiveOrg();
   const search = useSearchParams();
-  const qs = search.toString();
   const exportHref = orgId
     ? `/api/bank/tx/export?${new URLSearchParams({ org_id: orgId, ...Object.fromEntries(search.entries()) }).toString()}`
     : "#";
+
+  if (isLoading) {
+    return (
+      <div className="p-4 md:p-6 max-w-6xl mx-auto">
+        <div className="glass-card p-6 max-w-md">
+          <h1 className="text-lg font-semibold mb-2">
+            <span className="emoji">🏦</span> Sanoa Bank
+          </h1>
+          <p className="text-sm text-slate-600">Cargando organizaciones…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!orgId) {
+    return (
+      <div className="p-4 md:p-6 max-w-6xl mx-auto">
+        <div className="glass-card p-6 max-w-md">
+          <h1 className="text-lg font-semibold mb-2">
+            <span className="emoji">🏦</span> Sanoa Bank
+          </h1>
+          <p className="mb-4">Selecciona una organización activa para continuar.</p>
+          <div className="flex flex-col gap-3">
+            <OrgSwitcherBadge variant="inline" />
+            <Link
+              href="/organizaciones"
+              className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+            >
+              Administrar organizaciones
+            </Link>
+            <p className="text-xs text-slate-500">
+              Tip: también puedes cambiar de organización desde la esquina superior derecha.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 md:p-6 max-w-6xl mx-auto">
@@ -22,29 +59,20 @@ export default function BankTxPage() {
         <h1 className="text-2xl font-semibold">Banco · Transacciones</h1>
         <a
           href={exportHref}
-          className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl border ${orgId ? "hover:shadow-sm" : "opacity-60 pointer-events-none"}`}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:shadow-sm"
           title="Exportar CSV (respeta filtros)"
         >
           Exportar CSV
         </a>
       </div>
 
-      {!orgId && (
-        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3 mt-2">
-          Selecciona una organización activa para continuar.
-        </p>
-      )}
-      {orgId && (
-        <>
-          <div className="mt-3">
-            <SavedViewsBar orgId={orgId} scope="bank_tx" />
-          </div>
-          <div className="mt-4">
-            <TxFilters />
-          </div>
-          <TxTable orgId={orgId} />
-        </>
-      )}
+      <div className="mt-3">
+        <SavedViewsBar orgId={orgId} scope="bank_tx" />
+      </div>
+      <div className="mt-4">
+        <TxFilters />
+      </div>
+      <TxTable orgId={orgId} />
     </div>
   );
 }

--- a/components/OrgSwitcherBadge.tsx
+++ b/components/OrgSwitcherBadge.tsx
@@ -4,7 +4,11 @@ import { listMyOrgs, getCurrentOrgId, setCurrentOrgId, type MyOrg } from "@/lib/
 import ColorEmoji from "@/components/ColorEmoji";
 import { showToast } from "@/components/Toaster";
 
-export default function OrgSwitcherBadge() {
+type OrgSwitcherBadgeProps = {
+  variant?: "fixed" | "inline";
+};
+
+export default function OrgSwitcherBadge({ variant = "fixed" }: OrgSwitcherBadgeProps) {
   const [orgs, setOrgs] = useState<MyOrg[]>([]);
   const [current, setCurrent] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -25,10 +29,10 @@ export default function OrgSwitcherBadge() {
     return () => window.removeEventListener("sanoa:org-changed", onChanged);
   }, []);
 
-  if (!current || orgs.length <= 1) return null;
+  if (variant !== "inline" && orgs.length <= 1) return null;
 
   const cur = orgs.find((o) => o.id === current);
-  const label = cur ? (cur.is_personal ? "Personal" : cur.name) : "Organización";
+  const label = cur ? (cur.is_personal ? "Personal" : cur.name) : "Selecciona organización";
 
   async function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const v = e.target.value;
@@ -42,6 +46,43 @@ export default function OrgSwitcherBadge() {
       showToast(err?.message || "No se pudo cambiar la organización.", "error");
     }
     setOpen(false);
+  }
+
+  if (variant === "inline") {
+    if (orgs.length === 0) {
+      return (
+        <div className="flex w-full flex-col gap-1 rounded-xl border border-dashed border-[var(--color-brand-border)] bg-white/70 p-3 text-sm text-slate-500">
+          No tienes organizaciones disponibles todavía.
+        </div>
+      );
+    }
+
+    const value = cur ? cur.id : "";
+
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <label className="text-sm font-medium text-slate-600">Organización</label>
+        <div className="flex items-center gap-2">
+          <ColorEmoji token="laboratorio" size={16} />
+          <select
+            value={value}
+            onChange={onChange}
+            className="w-full rounded-xl border border-[var(--color-brand-border)] bg-white px-3 py-2 text-sm"
+          >
+            {!cur && (
+              <option value="" disabled>
+                Selecciona organización…
+              </option>
+            )}
+            {orgs.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.is_personal ? "Personal" : o.name} {o.role !== "owner" ? `· ${o.role}` : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -63,6 +104,9 @@ export default function OrgSwitcherBadge() {
             onChange={onChange}
             className="w-full rounded-xl border border-[var(--color-brand-border)] bg-white px-3 py-2 text-sm"
           >
+            <option value="" disabled>
+              Selecciona organización…
+            </option>
             {orgs.map((o) => (
               <option key={o.id} value={o.id}>
                 {o.is_personal ? "Personal" : o.name} {o.role !== "owner" ? `· ${o.role}` : ""}

--- a/hooks/useBankActiveOrg.ts
+++ b/hooks/useBankActiveOrg.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { listMyOrgs, setCurrentOrgId, type MyOrg } from "@/lib/org";
+import { getActiveOrg, setActiveOrg } from "@/lib/org-local";
+
+const NEW_STORAGE_KEY = "sanoa.currentOrg";
+
+type ActiveOrgState = {
+  orgId: string | null;
+  isLoading: boolean;
+};
+
+export function useBankActiveOrg(): ActiveOrgState {
+  const initial = getActiveOrg();
+  const [orgId, setOrgId] = useState<string | null>(initial.id ?? null);
+  const [isLoading, setIsLoading] = useState<boolean>(() => !initial.id);
+  const orgsRef = useRef<MyOrg[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function bootstrap() {
+      if (orgId) {
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const list = await listMyOrgs();
+        if (!mounted) return;
+        orgsRef.current = list;
+
+        if (list.length === 1) {
+          const unique = list[0];
+          try {
+            await setCurrentOrgId(unique.id);
+          } catch {
+            // ignore: graceful fallback without blocking UI
+          }
+          setActiveOrg(unique.id, unique.name);
+          if (!mounted) return;
+          setOrgId(unique.id);
+          return;
+        }
+
+        if (typeof window !== "undefined") {
+          try {
+            const storedId = window.localStorage.getItem(NEW_STORAGE_KEY);
+            if (storedId) {
+              const match = list.find((item) => item.id === storedId);
+              if (match) {
+                setActiveOrg(match.id, match.name);
+                if (!mounted) return;
+                setOrgId(match.id);
+                return;
+              }
+            }
+          } catch {
+            // ignore storage errors silently
+          }
+        }
+      } catch {
+        // ignore errors: component will fall back to empty state
+      } finally {
+        if (mounted) setIsLoading(false);
+      }
+    }
+
+    void bootstrap();
+
+    const handleChange = async (event: Event) => {
+      if (!mounted) return;
+      const detail = (event as CustomEvent).detail as { orgId?: string | null } | undefined;
+      const nextId = detail?.orgId ?? null;
+      if (!nextId) {
+        setActiveOrg(null);
+        setOrgId(null);
+        return;
+      }
+
+      let list = orgsRef.current;
+      if (!list || list.length === 0) {
+        try {
+          list = await listMyOrgs();
+          if (mounted) orgsRef.current = list;
+        } catch {
+          list = [];
+        }
+      }
+
+      const match = list.find((item) => item.id === nextId);
+      setActiveOrg(nextId, match?.name);
+      setOrgId(nextId);
+    };
+
+    window.addEventListener("sanoa:org-changed", handleChange);
+
+    return () => {
+      mounted = false;
+      window.removeEventListener("sanoa:org-changed", handleChange);
+    };
+  }, [orgId]);
+
+  return { orgId, isLoading };
+}


### PR DESCRIPTION
## Summary
- add a client hook that synchronizes the active organization, auto-selecting when only one option exists
- gate the bank transactions and rules pages with a glass card that surfaces the inline organization selector and CTA when no org is active
- extend `OrgSwitcherBadge` with an inline variant so the selector can render inside the gating card while keeping the floating badge behavior

## Testing
- pnpm lint *(fails: missing `@eslint/js` required by eslint.config.mjs)*
- pnpm typecheck *(fails: existing type errors across unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dc403a75bc832a81ef5b1a8e6ceb67