### PR TITLE
Improve navbar accessibility and glass card contrast

### DIFF
--- a/app/(app)/buscador/page.tsx
+++ b/app/(app)/buscador/page.tsx
@@ -63,50 +63,50 @@ export default function SearchPage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-4 space-y-4">
-      <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Buscador</h1>
-      <div className="glass rounded-xl p-4 space-y-3">
+    <div className="max-w-4xl mx-auto p-5 space-y-5">
+      <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Buscador</h1>
+      <div className="glass glass-card bubble p-5 space-y-4 text-contrast">
         <div className="flex gap-2">
           <Input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Ej: ansiedad, informe laboratorio, etc."
           />
-          <Button onClick={() => void run()} disabled={loading}>
-            Buscar
+          <Button onClick={() => void run()} disabled={loading} className="glass-btn neon">
+            {loading ? "🔍 Buscando…" : "🚀 Buscar"}
           </Button>
         </div>
-        <div className="text-xs text-slate-600 dark:text-slate-300">
-          <Button variant="secondary" onClick={() => void reindex("notes")} disabled={loading}>
-            Reindexar notas
+        <div className="text-xs text-slate-600 dark:text-slate-300 flex flex-wrap items-center gap-2">
+          <Button variant="secondary" onClick={() => void reindex("notes")} disabled={loading} className="glass-btn">
+            📝 Reindexar notas
           </Button>
           <Button
             variant="secondary"
-            className="ml-2"
+            className="glass-btn"
             onClick={() => void reindex("files")}
             disabled={loading}
           >
-            Reindexar archivos
+            📁 Reindexar archivos
           </Button>
           {mode && (
-            <span className="ml-3">
+            <span className="ml-1 text-xs text-foreground/80">
               Modo: <strong>{mode}</strong>
             </span>
           )}
         </div>
       </div>
 
-      <div className="glass rounded-xl divide-y divide-black/5 dark:divide-white/10">
+      <div className="glass glass-card bubble text-contrast divide-y divide-black/5 dark:divide-white/10">
         {rows.length === 0 && (
-          <div className="p-4 text-sm text-slate-600 dark:text-slate-300">Sin resultados.</div>
+          <div className="p-4 text-sm opacity-80">Sin resultados.</div>
         )}
         {rows.map((r, i) => (
           <div key={i} className="p-3">
-            <div className="text-xs text-slate-600 dark:text-slate-300">
+            <div className="text-xs opacity-80">
               {r.kind === "note" ? "Nota" : "Archivo"} · Paciente {r.patient_id.slice(0, 8)}… ·
               score {r.score.toFixed(2)}
             </div>
-            <div className="text-slate-900 dark:text-white whitespace-pre-wrap">{r.snippet}</div>
+            <div className="whitespace-pre-wrap text-base leading-relaxed">{r.snippet}</div>
           </div>
         ))}
       </div>

--- a/app/(app)/especialidades/page.tsx
+++ b/app/(app)/especialidades/page.tsx
@@ -12,22 +12,29 @@ const areas = [
 
 export default function AreasProPage() {
   return (
-    <div className="mx-auto max-w-6xl px-4 py-6">
-      <h1 className="text-3xl font-semibold mb-6">Áreas Pro</h1>
+    <div className="mx-auto max-w-6xl px-5 py-8 space-y-6">
+      <h1 className="text-4xl font-semibold tracking-tight">Áreas Pro</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
         {areas.map((a) => (
-          <Card key={a.href} className="glass p-5 hover:scale-[1.01] transition">
-            <div className="text-4xl mb-3">{a.emoji}</div>
-            <h2 className="text-xl font-medium">{a.title}</h2>
-            <p className="text-sm opacity-80 mb-4">{a.desc}</p>
+          <Card
+            key={a.href}
+            className="bubble text-contrast p-6 hover:-translate-y-1 hover:shadow-xl transition"
+          >
+            <div className="text-4xl mb-3" aria-hidden>
+              {a.emoji}
+            </div>
+            <h2 className="text-2xl font-semibold tracking-tight">{a.title}</h2>
+            <p className="text-sm opacity-80 mb-5 leading-relaxed">{a.desc}</p>
             <div className="flex gap-2">
               <Link href={a.href} className="grow">
-                <Button className="w-full glass-btn" type="button">
+                <Button className="w-full glass-btn neon" type="button">
                   🚀 Abrir (Vista previa)
                 </Button>
               </Link>
               <Link href={`/banco?sku=${encodeURIComponent("areas-pro.destacado")}`}>
-                <Button variant="outline" className="glass-btn">💳 Desbloquear</Button>
+                <Button variant="outline" className="glass-btn">
+                  💳 Desbloquear
+                </Button>
               </Link>
             </div>
           </Card>

--- a/app/(app)/reportes/page.tsx
+++ b/app/(app)/reportes/page.tsx
@@ -114,10 +114,10 @@ export default function ReportsPage() {
     new Date(m).toLocaleDateString(undefined, { month: "short", year: "2-digit" });
 
   return (
-    <div className="max-w-5xl mx-auto p-4 space-y-6">
+    <div className="max-w-5xl mx-auto p-5 space-y-7">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Reportes</h1>
-        <div className="flex items-center gap-3">
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Reportes</h1>
+        <div className="flex items-center gap-3 text-base">
           <label className="text-sm text-slate-600 dark:text-slate-200">
             Meses
             <Input
@@ -134,7 +134,7 @@ export default function ReportsPage() {
             />
           </label>
           <Button variant="secondary" onClick={() => void load()} disabled={loading}>
-            {loading ? "Actualizando…" : "Actualizar"}
+            {loading ? "⏳ Actualizando…" : "🔄 Actualizar"}
           </Button>
         </div>
       </div>
@@ -147,7 +147,7 @@ export default function ReportsPage() {
         </div>
       )}
 
-      <section className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+      <section className="grid grid-cols-1 sm:grid-cols-4 gap-4">
         <Card title="Pacientes totales" value={kv("patients_total")} loading={loading} />
         <Card title="Notas (30d)" value={kv("notes_30d")} loading={loading} />
         <Card title="Archivos (30d)" value={kv("files_30d")} loading={loading} />
@@ -183,9 +183,9 @@ export default function ReportsPage() {
 
 function Card({ title, value, loading }: { title: string; value: number; loading?: boolean }) {
   return (
-    <div className="p-4 glass rounded-xl">
-      <div className="text-sm text-slate-600 dark:text-slate-200">{title}</div>
-      <div className="text-2xl font-semibold text-slate-900 dark:text-white">
+    <div className="glass glass-card bubble text-contrast p-5 transition-transform duration-150 hover:translate-y-[-2px] hover:shadow-xl">
+      <div className="text-sm font-medium opacity-80">{title}</div>
+      <div className="mt-1 text-3xl font-semibold tracking-tight">
         {loading ? "…" : Number(value).toLocaleString()}
       </div>
     </div>
@@ -207,22 +207,22 @@ function Series({
 }) {
   return (
     <section className="space-y-2">
-      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
-      <div className="glass rounded-xl divide-y divide-black/5 dark:divide-white/10">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{title}</h2>
+      <div className="glass glass-card bubble text-contrast divide-y divide-black/5 dark:divide-white/10">
         {loading && rows.length === 0 && (
-          <div className="p-4 text-sm text-slate-600 dark:text-slate-300">Cargando…</div>
+          <div className="p-4 text-sm opacity-80">Cargando…</div>
         )}
         {rows.map((p) => (
           <div key={p.month_start} className="p-3">
             <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-600 dark:text-slate-300">{fmt(p.month_start)}</div>
-              <div className="text-sm text-slate-900 dark:text-white">{p.total}</div>
+              <div className="text-sm opacity-80">{fmt(p.month_start)}</div>
+              <div className="text-sm font-semibold">{p.total}</div>
             </div>
             <Bar value={p.total} max={max} />
           </div>
         ))}
         {!loading && rows.length === 0 && (
-          <div className="p-4 text-sm text-slate-600 dark:text-slate-300">Sin datos.</div>
+          <div className="p-4 text-sm opacity-80">Sin datos.</div>
         )}
       </div>
     </section>
@@ -257,12 +257,12 @@ function Cohorts() {
 
   return (
     <section className="space-y-2">
-      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
         Cohortes (retención por mes de alta)
       </h2>
-      <div className="glass rounded-xl overflow-auto">
+      <div className="glass glass-card bubble overflow-auto text-contrast">
         <table className="min-w-[640px] w-full text-sm">
-          <thead className="bg-black/5 dark:bg-white/10">
+          <thead className="bg-black/5 dark:bg-white/10 text-contrast">
             <tr>
               <th className="text-left p-2">Cohorte</th>
               <th className="text-right p-2">Usuarios</th>
@@ -288,14 +288,14 @@ function Cohorts() {
             ))}
             {loading && (
               <tr>
-                <td colSpan={5} className="p-3 text-slate-600 dark:text-slate-300">
+                <td colSpan={5} className="p-3 text-sm opacity-80">
                   Cargando…
                 </td>
               </tr>
             )}
             {!loading && rows.length === 0 && (
               <tr>
-                <td colSpan={5} className="p-3 text-slate-600 dark:text-slate-300">
+                <td colSpan={5} className="p-3 text-sm opacity-80">
                   Sin datos.
                 </td>
               </tr>

--- a/app/globals.css
+++ b/app/globals.css
@@ -499,6 +499,24 @@ button {
 html { font-size: clamp(17px, calc(16px * var(--scale)), 19px); }
 * { -webkit-tap-highlight-color: transparent; }
 
+.glass-card,
+.text-contrast {
+  --surface-text-color: #0f172a;
+  --color-brand-text: var(--surface-text-color);
+  color: var(--surface-text-color);
+}
+
+.glass-card :is(a, h1, h2, h3, h4, h5, h6, p, span, strong, em),
+.text-contrast :is(a, h1, h2, h3, h4, h5, h6, p, span, strong, em) {
+  color: inherit;
+}
+
+.dark .glass-card,
+.dark .text-contrast {
+  --surface-text-color: rgba(248, 250, 252, 0.94);
+  color: var(--surface-text-color);
+}
+
 .glass {
   position: relative;
   background: var(--glass-bg);
@@ -570,4 +588,39 @@ html { font-size: clamp(17px, calc(16px * var(--scale)), 19px); }
 
 .emoji-lg {
   font-size: calc(var(--emoji-size) * 1.2);
+}
+
+/* Variantes visuales */
+.bubble {
+  border-radius: 1.5rem;
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  box-shadow: 0 26px 54px rgba(15, 23, 42, 0.18);
+  border: 1px solid var(--glass-border-strong);
+}
+
+.dark .bubble {
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.55);
+  border-color: var(--glass-border-strong);
+}
+
+.neon {
+  position: relative;
+}
+
+.neon::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 1.1rem;
+  pointer-events: none;
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.35);
+  opacity: 0;
+  transition: opacity 0.2s ease, box-shadow 0.2s ease;
+}
+
+.neon:hover::after,
+.neon:focus-visible::after {
+  opacity: 1;
+  box-shadow: 0 0 26px rgba(56, 189, 248, 0.45);
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -50,11 +50,11 @@ export default function Navbar() {
 
   return (
     <header className="sticky top-0 z-40 border-b border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
-      <div className="mx-auto max-w-6xl px-4 h-16 flex items-center justify-between gap-4">
+      <div className="mx-auto max-w-6xl px-5 h-[4.5rem] flex items-center justify-between gap-4 text-base">
         {/* Brand */}
         <Link
           href="/consultorio"
-          className="inline-flex items-center gap-2"
+          className="inline-flex items-center gap-2 rounded-xl px-1.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
           aria-label="Ir a Consultorio"
         >
           <span className="inline-grid place-content-center h-9 w-9 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800">
@@ -64,7 +64,7 @@ export default function Navbar() {
         </Link>
 
         {/* Nav */}
-        <nav className="hidden md:flex items-center gap-1 text-[17px]">
+        <nav className="hidden md:flex items-center gap-1.5 text-[1.05rem]">
           {NAV.map((item) => {
             const isActive =
               pathname === item.href ||
@@ -75,15 +75,16 @@ export default function Navbar() {
                 href={item.href}
                 aria-current={isActive ? "page" : undefined}
                 className={[
-                  "inline-flex items-center gap-3 px-3 py-3 rounded-lg border transition",
-                  "text-slate-700 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-white/10",
+                  "inline-flex items-center gap-3 px-3.5 py-3.5 rounded-xl border transition font-semibold tracking-tight",
+                  "text-slate-700 dark:text-slate-100 hover:bg-slate-50/90 dark:hover:bg-white/10",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
                   isActive
                     ? "bg-white dark:bg-white/10 border-slate-200 dark:border-slate-700"
                     : "border-transparent",
                 ].join(" ")}
               >
                 <EmojiIcon emoji={item.emoji} title={item.label} />
-                <span className="font-medium text-[17px]">{item.label}</span>
+                <span className="font-semibold text-[1.05rem]">{item.label}</span>
               </Link>
             );
           })}
@@ -94,7 +95,7 @@ export default function Navbar() {
           <button
             onClick={handleSignOut}
             disabled={signingOut}
-            className="inline-flex items-center gap-2 px-3 py-3 rounded-xl bg-rose-500 text-white text-[17px] hover:brightness-95 active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed transition"
+            className="inline-flex items-center gap-2 px-4 py-3.5 rounded-2xl bg-rose-500 text-white text-[1.05rem] font-semibold shadow-md hover:brightness-95 active:brightness-90 disabled:opacity-60 disabled:cursor-not-allowed transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
             title="Cerrar sesión"
           >
             <ColorEmoji token="desbloquear" />

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-base font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -19,10 +19,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-10 px-5 py-2.5 has-[>svg]:px-4",
+        sm: "h-9 rounded-md gap-1.5 px-3.5 has-[>svg]:px-2.5 text-sm",
+        lg: "h-11 rounded-md px-7 has-[>svg]:px-5",
+        icon: "size-10",
       },
     },
     defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "glass flex flex-col gap-6 rounded-xl border border-transparent p-4 shadow-sm",
+        "glass glass-card flex flex-col gap-6 rounded-2xl border border-transparent p-6 shadow-sm",
         className,
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("font-semibold leading-none", className)}
+      className={cn("font-semibold leading-tight text-xl", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- increase navbar typography and focus treatments for better readability and visible focus states
- introduce shared text-contrast utilities plus bubble/neon accents for glass cards and buttons
- refresh report, search, and areas pages to use the new contrast helpers and larger headings/buttons

## Testing
- `pnpm lint` *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc424bb984832a97417f42f1a2489d