### PR TITLE
feat: enhance navbar and glass surfaces accessibility

### DIFF
--- a/app/(app)/banco/reglas/page.tsx
+++ b/app/(app)/banco/reglas/page.tsx
@@ -10,12 +10,12 @@ export default function BankRulesPage() {
 
   if (isLoading) {
     return (
-      <div className="p-4 md:p-6 max-w-6xl mx-auto">
-        <div className="glass-card p-6 max-w-md">
-          <h1 className="text-lg font-semibold mb-2">
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        <div className="glass-card bubble text-contrast max-w-md p-6">
+          <h1 className="mb-3 text-2xl font-semibold">
             <span className="emoji">🏦</span> Sanoa Bank
           </h1>
-          <p className="text-sm text-slate-600">Cargando organizaciones…</p>
+          <p className="text-base text-slate-600 dark:text-slate-200/90">Cargando organizaciones…</p>
         </div>
       </div>
     );
@@ -23,21 +23,26 @@ export default function BankRulesPage() {
 
   if (!orgId) {
     return (
-      <div className="p-4 md:p-6 max-w-6xl mx-auto">
-        <div className="glass-card p-6 max-w-md">
-          <h1 className="text-lg font-semibold mb-2">
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        <div className="glass-card bubble text-contrast max-w-md p-6">
+          <h1 className="mb-3 text-2xl font-semibold">
             <span className="emoji">🏦</span> Sanoa Bank
           </h1>
-          <p className="mb-4">Selecciona una organización activa para continuar.</p>
+          <p className="mb-4 text-base text-slate-700 dark:text-slate-200">
+            Selecciona una organización activa para continuar.
+          </p>
           <div className="flex flex-col gap-3">
             <OrgSwitcherBadge variant="inline" />
             <Link
               href="/organizaciones"
-              className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+              className="glass-btn bubble text-base font-semibold text-slate-700 transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900"
             >
+              <span className="emoji" aria-hidden>
+                🧭
+              </span>
               Administrar organizaciones
             </Link>
-            <p className="text-xs text-slate-500">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
               Tip: también puedes cambiar de organización desde la esquina superior derecha.
             </p>
           </div>
@@ -47,8 +52,8 @@ export default function BankRulesPage() {
   }
 
   return (
-    <div className="p-4 md:p-6 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-2">Banco · Reglas</h1>
+    <div className="mx-auto max-w-6xl p-4 md:p-6">
+      <h1 className="mb-3 text-3xl font-semibold tracking-tight">Banco · Reglas</h1>
       <RulesEditor />
     </div>
   );

--- a/app/(app)/banco/tx/page.tsx
+++ b/app/(app)/banco/tx/page.tsx
@@ -22,12 +22,12 @@ export default function BankTxPage() {
 
   if (isLoading) {
     return (
-      <div className="p-4 md:p-6 max-w-6xl mx-auto">
-        <div className="glass-card p-6 max-w-md">
-          <h1 className="text-lg font-semibold mb-2">
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        <div className="glass-card bubble text-contrast max-w-md p-6">
+          <h1 className="mb-3 text-2xl font-semibold">
             <span className="emoji">🏦</span> Sanoa Bank
           </h1>
-          <p className="text-sm text-slate-600">Cargando organizaciones…</p>
+          <p className="text-base text-slate-600 dark:text-slate-200/90">Cargando organizaciones…</p>
         </div>
       </div>
     );
@@ -35,21 +35,26 @@ export default function BankTxPage() {
 
   if (!orgId) {
     return (
-      <div className="p-4 md:p-6 max-w-6xl mx-auto">
-        <div className="glass-card p-6 max-w-md">
-          <h1 className="text-lg font-semibold mb-2">
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        <div className="glass-card bubble text-contrast max-w-md p-6">
+          <h1 className="mb-3 text-2xl font-semibold">
             <span className="emoji">🏦</span> Sanoa Bank
           </h1>
-          <p className="mb-4">Selecciona una organización activa para continuar.</p>
+          <p className="mb-4 text-base text-slate-700 dark:text-slate-200">
+            Selecciona una organización activa para continuar.
+          </p>
           <div className="flex flex-col gap-3">
             <OrgSwitcherBadge variant="inline" />
             <Link
               href="/organizaciones"
-              className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+              className="glass-btn bubble text-base font-semibold text-slate-700 transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900"
             >
+              <span className="emoji" aria-hidden>
+                🧭
+              </span>
               Administrar organizaciones
             </Link>
-            <p className="text-xs text-slate-500">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
               Tip: también puedes cambiar de organización desde la esquina superior derecha.
             </p>
           </div>
@@ -59,14 +64,17 @@ export default function BankTxPage() {
   }
 
   return (
-    <div className="p-4 md:p-6 max-w-6xl mx-auto">
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold">Banco · Transacciones</h1>
+    <div className="mx-auto max-w-6xl p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-3xl font-semibold tracking-tight">Banco · Transacciones</h1>
         <a
           href={exportHref}
-          className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border hover:shadow-sm"
+          className="glass-btn neon bubble inline-flex items-center gap-2 text-base font-semibold text-slate-700 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900"
           title="Exportar CSV (respeta filtros)"
         >
+          <span className="emoji" aria-hidden>
+            📤
+          </span>
           Exportar CSV
         </a>
       </div>

--- a/app/(app)/consultorio/page.tsx
+++ b/app/(app)/consultorio/page.tsx
@@ -1,24 +1,36 @@
 "use client";
 
+import Link from "next/link";
 import * as React from "react";
 import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
 import { getActiveOrg } from "@/lib/org-local";
+
+const CARD_ICONS: Record<string, string> = {
+  agenda: "🗓️",
+  pacientes: "🧑‍⚕️",
+  recetas: "💊",
+  laboratorio: "🧪",
+  recordatorios: "🔔",
+  reportes: "📊",
+};
 
 export default function Page() {
   const org = React.useMemo(() => getActiveOrg(), []);
   const orgId = org?.id || "";
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">
+    <div className="space-y-7">
+      <h1 className="text-3xl font-semibold tracking-tight">
         <span className="emoji">🏥</span> Mi Consultorio
       </h1>
-      <p className="text-sm text-slate-600 dark:text-slate-300">
+      <p className="text-base text-slate-600 dark:text-slate-300">
         Tu centro operativo: agenda, pacientes, recetas, laboratorio, recordatorios.
       </p>
 
-      <div className="glass-card">
-        <label className="block text-sm mb-2">Buscar paciente</label>
+      <div className="glass-card bubble text-contrast">
+        <label className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
+          Buscar paciente
+        </label>
         <div className="relative">
           {orgId ? (
             <PatientAutocomplete
@@ -43,7 +55,7 @@ export default function Page() {
         <p className="mt-2 text-xs text-slate-500">Verás pacientes de tu organización activa.</p>
       </div>
 
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <CardLink
           href="/agenda"
           token="agenda"
@@ -96,17 +108,24 @@ function CardLink({
   title: string;
   desc: string;
 }) {
+  const emoji = CARD_ICONS[token] ?? "✨";
+
   return (
-    <a href={href} className="rounded-2xl border p-4 hover:shadow-sm transition">
-      <div className="flex items-start gap-3">
-        <div className="h-10 w-10 rounded-xl border inline-grid place-content-center">
-          <span className="emoji">{/* opcional: ícono según token */}</span>
+    <Link
+      href={href}
+      className="glass-card bubble text-contrast transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+    >
+      <div className="flex items-start gap-4">
+        <div className="inline-grid h-12 w-12 place-content-center rounded-xl border border-white/40 bg-white/50 text-lg dark:border-slate-700/60 dark:bg-slate-900/60">
+          <span className="emoji" aria-hidden>
+            {emoji}
+          </span>
         </div>
-        <div>
-          <h3 className="font-semibold">{title}</h3>
-          <p className="text-sm text-slate-600">{desc}</p>
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <p className="text-sm text-slate-600 dark:text-slate-200/90">{desc}</p>
         </div>
       </div>
-    </a>
+    </Link>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -492,9 +492,9 @@ button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    padding: 0.65rem 1.25rem;
+    font-size: 0.95rem;
+    font-weight: 600;
     gap: 0.5rem;
   }
 
@@ -507,8 +507,8 @@ button {
   }
 
   .glass-btn:focus-visible {
-    outline: 2px solid rgba(14, 165, 233, 0.5);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
   }
 
   .glass-btn:disabled {
@@ -555,4 +555,28 @@ button {
     backdrop-filter: blur(2px);
     -webkit-backdrop-filter: blur(2px);
   }
+}
+
+/* Burbuja: más blur y sombra suave */
+.bubble {
+  border-radius: 1rem;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: var(--glass-shadow);
+  background: rgba(var(--glass-bg));
+  border: 1px solid rgba(var(--glass-stroke));
+}
+
+/* Neón suave: resalta acciones primarias */
+.neon {
+  position: relative;
+}
+
+.neon::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 1.1rem;
+  pointer-events: none;
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.35);
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -56,13 +56,13 @@ export default function Navbar() {
   }
 
   return (
-    <header className="sticky top-0 z-50 px-3 py-3 sm:px-4">
+    <header className="sticky top-0 z-50 px-3 py-4 sm:px-5">
       <div className="mx-auto max-w-6xl">
-        <div className="glass relative flex items-center gap-3 rounded-2xl border border-white/20 px-4 py-3 shadow-lg backdrop-blur">
+        <div className="glass bubble relative flex items-center gap-3 px-5 py-4">
           {/* Brand */}
           <Link
             href="/dashboard"
-            className="inline-flex items-center gap-2 text-base font-semibold tracking-tight text-slate-900 transition hover:opacity-90 dark:text-white"
+            className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-white dark:focus-visible:ring-offset-slate-900 md:text-xl"
             aria-label="Ir al dashboard"
           >
             <span className="emoji">✨</span>
@@ -70,7 +70,10 @@ export default function Navbar() {
           </Link>
 
           {/* Main nav */}
-          <nav className="ml-3 flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto whitespace-nowrap">
+          <nav
+            className="ml-4 flex min-w-0 flex-1 items-center gap-2 overflow-x-auto whitespace-nowrap"
+            aria-label="Secciones principales"
+          >
             {NAV.map((item) => {
               const isActive =
                 pathname === item.href ||
@@ -82,10 +85,10 @@ export default function Navbar() {
                   href={item.href}
                   aria-current={isActive ? "page" : undefined}
                   className={cn(
-                    "glass-btn inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-slate-700 transition-colors dark:text-slate-100",
+                    "glass-btn bubble text-base font-semibold text-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900",
                     isActive
-                      ? "ring-2 ring-sky-500/40 bg-white/80 text-slate-900 dark:bg-slate-900/70 dark:text-white"
-                      : "bg-white/60 hover:bg-white/70 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
+                      ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
+                      : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
                   )}
                 >
                   <span className="emoji mr-1" aria-hidden>
@@ -98,7 +101,10 @@ export default function Navbar() {
           </nav>
 
           {/* Quick links */}
-          <div className="ml-auto hidden flex-wrap items-center justify-end gap-2 sm:flex">
+          <div
+            className="ml-auto hidden flex-wrap items-center justify-end gap-2 sm:flex"
+            aria-label="Accesos rápidos"
+          >
             {QUICK_LINKS.map((item) => {
               const isActive =
                 pathname === item.href ||
@@ -109,10 +115,10 @@ export default function Navbar() {
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    "glass-btn inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-slate-700 transition-colors dark:text-slate-100",
+                    "glass-btn bubble text-base font-semibold text-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900",
                     isActive
-                      ? "ring-2 ring-sky-500/40 bg-white/80 text-slate-900 dark:bg-slate-900/70 dark:text-white"
-                      : "bg-white/60 hover:bg-white/70 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
+                      ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
+                      : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
                   )}
                 >
                   <span className="emoji mr-1" aria-hidden>
@@ -128,7 +134,7 @@ export default function Navbar() {
           <button
             onClick={handleSignOut}
             disabled={signingOut}
-            className="glass-btn ml-2 inline-flex shrink-0 items-center gap-2 px-3 py-2 text-sm font-semibold text-rose-600 transition-colors hover:bg-white/70 disabled:cursor-not-allowed disabled:opacity-70 dark:text-rose-200 dark:hover:bg-slate-950/55"
+            className="glass-btn neon ml-3 inline-flex shrink-0 items-center gap-2 text-base text-rose-600 transition-colors hover:bg-white/75 disabled:cursor-not-allowed disabled:opacity-70 focus-visible:ring-2 focus-visible:ring-rose-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-rose-200 dark:hover:bg-slate-950/55 dark:focus-visible:ring-offset-slate-900"
             aria-busy={signingOut}
           >
             <span className="emoji" aria-hidden>


### PR DESCRIPTION
## Summary
- refresh the navbar with larger typography, glass "bubble" styling, and improved focus-visible states while keeping emoji cues on every action
- introduce reusable bubble and neon accents plus refined glass button sizing to boost contrast across light and dark themes
- update consultorio and banco pages to apply text-contrast glass cards, richer copy, and accent buttons with accessible focus rings

## Testing
- `pnpm lint` *(fails: missing peer dependency @eslint/js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5f982198832a9d59377a0ad9edca