### PR TITLE
Add emoji affordances to scheduling and patient exports

### DIFF
--- a/app/(app)/agenda/page.tsx
+++ b/app/(app)/agenda/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
 import { fetchBookings, type CalBooking } from "@/lib/cal";
 import { listPatients, type Patient } from "@/lib/patients";
 import { Input } from "@/components/ui/input";
@@ -76,6 +77,16 @@ export default function AgendaPage() {
     const beforeEnd = to ? new Date(to + "T23:59:59").toISOString() : undefined;
     return { afterStart, beforeEnd };
   }, [from, to]);
+
+  const exportUrl = useMemo(() => {
+    if (!org.id) return "";
+    const params = new URLSearchParams({ org_id: org.id });
+    if (range.afterStart) params.set("from", range.afterStart);
+    if (range.beforeEnd) params.set("to", range.beforeEnd);
+    if (status !== "all") params.set("status", status);
+    if (q.trim()) params.set("q", q.trim());
+    return `/api/export/agenda/xlsx?${params.toString()}`;
+  }, [org.id, range.afterStart, range.beforeEnd, status, q]);
 
   async function load() {
     setLoading(true);
@@ -215,12 +226,33 @@ export default function AgendaPage() {
 
   return (
     <div className="max-w-6xl mx-auto p-4 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl md:text-3xl font-semibold flex items-center gap-2">
           <ColorEmoji token="agenda" />
           <span>Agenda</span>
         </h1>
-        <Button onClick={() => setOpenNew(true)}>Nueva cita</Button>
+        <div className="flex items-center gap-2">
+          <a
+            href={exportUrl || undefined}
+            onClick={(e) => {
+              if (!exportUrl) e.preventDefault();
+            }}
+            className={clsx(
+              "inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-sm transition",
+              "bg-white/80 hover:bg-white dark:bg-slate-900/60 dark:hover:bg-slate-900/80",
+              !exportUrl && "pointer-events-none opacity-50",
+            )}
+            aria-disabled={!exportUrl}
+            title={exportUrl ? "Exportar agenda en XLSX" : "Activa una organización para exportar"}
+          >
+            <span aria-hidden>📤</span>
+            <span>Exportar</span>
+          </a>
+          <Button onClick={() => setOpenNew(true)} className="gap-2">
+            <span aria-hidden>➕</span>
+            <span>Agregar cita</span>
+          </Button>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-6 gap-3">
@@ -296,7 +328,7 @@ export default function AgendaPage() {
       </div>
 
       {/* Modal NUEVA CITA */}
-      <Modal open={openNew} onOpenChange={() => setOpenNew(false)} title="Nueva cita">
+      <Modal open={openNew} onOpenChange={() => setOpenNew(false)} title="Agregar cita">
         <div className="space-y-4">
           <div>
             <label className="text-sm block mb-1">Paciente</label>

--- a/app/(app)/pacientes/page.tsx
+++ b/app/(app)/pacientes/page.tsx
@@ -20,7 +20,6 @@ import clsx from "clsx";
 // NUEVO: shadcn/ui + lucide para botones/inputs modernos
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Download, Plus } from "lucide-react";
 
 /** Traducción/normalización de errores frecuentes en listados */
 function toSpanishListError(e: unknown): string {
@@ -296,8 +295,8 @@ export default function PacientesPage() {
       <div className="flex items-center justify-between">
         <a href={exportURL()} title="Exportar resultados a CSV">
           <Button variant="secondary" className="inline-flex items-center gap-2">
-            <Download className="w-4 h-4" />
-            CSV
+            <span aria-hidden>📤</span>
+            <span>Exportar CSV</span>
           </Button>
         </a>
         <Button
@@ -306,8 +305,8 @@ export default function PacientesPage() {
           disabled={loading}
           className="inline-flex items-center gap-2"
         >
-          <Plus className="w-4 h-4" />
-          Nuevo paciente
+          <span aria-hidden>➕</span>
+          <span>Nuevo paciente</span>
         </Button>
       </div>
 

--- a/app/(app)/recordatorios/page.tsx
+++ b/app/(app)/recordatorios/page.tsx
@@ -87,7 +87,8 @@ export default function RecordatoriosPage() {
               className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border"
               title="Exportar CSV (respeta filtros)"
             >
-              Exportar CSV
+              <span aria-hidden>📤</span>
+              <span>Exportar CSV</span>
             </a>
           </div>
 


### PR DESCRIPTION
## Summary
- add emoji affordances to the patient list action bar and reminders export link
- expose an agenda XLSX export shortcut and rename the add-appointment button with emoji context

## Testing
- pnpm lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5ffff8a4832aadac3dd8002cd20a