### PR TITLE
Improve specialties access messaging

### DIFF
--- a/app/(app)/areas/page.tsx
+++ b/app/(app)/areas/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { permanentRedirect } from "next/navigation";
 
 export default function AreasPage() {
-  redirect("/especialidades");
+  permanentRedirect("/especialidades");
 }

--- a/components/modules/ModuleGate.tsx
+++ b/components/modules/ModuleGate.tsx
@@ -9,7 +9,7 @@ export default function ModuleGate({
   children,
   className = "",
 }: React.PropsWithChildren<{ featureKey: string; className?: string }>) {
-  const { loading, locked } = useModuleAccess(featureKey);
+  const { loading, locked, bankReady } = useModuleAccess(featureKey);
 
   return (
     <div className={["relative", className].join(" ")}>
@@ -25,18 +25,32 @@ export default function ModuleGate({
           />
           <div className="absolute inset-x-0 top-[35%] flex justify-center px-4">
             <div className="rounded-2xl border bg-white/95 dark:bg-slate-900 p-4 shadow max-w-md w-full text-center">
-              <h4 className="font-semibold">Módulo Pro bloqueado</h4>
-              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
-                Desbloquea este módulo desde Sanoa Bank para empezar a usar sus funciones.
+              <div className="mb-2 flex justify-center">
+                <span className="rounded-full border border-amber-200 bg-amber-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-amber-800">
+                  Estado: Bloqueada
+                </span>
+              </div>
+              <h4 className="font-semibold text-lg text-[var(--color-brand-text)] dark:text-white">
+                Módulo Pro bloqueado
+              </h4>
+              <p className="text-sm text-slate-600 dark:text-slate-300 mt-2">
+                {bankReady
+                  ? "Desbloquea este módulo desde Sanoa Bank para empezar a usar sus funciones."
+                  : "Configura Sanoa Bank para habilitar los módulos Pro y gestionar accesos."}
               </p>
               <div className="mt-3 flex justify-center">
                 <Link
                   href="/banco"
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-amber-500 text-white"
+                  className="inline-flex items-center gap-2 rounded-2xl border border-emerald-400 bg-emerald-300 px-5 py-2 font-semibold text-emerald-950 shadow-[0_0_18px_rgba(52,211,153,0.55)] transition hover:-translate-y-0.5 hover:shadow-[0_0_26px_rgba(52,211,153,0.75)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
                 >
                   Desbloquear con Sanoa Bank
                 </Link>
               </div>
+              {!bankReady && (
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  Tip: configura tu cuenta bancaria primero para que podamos activar los módulos automáticamente.
+                </p>
+              )}
             </div>
           </div>
         </>

--- a/components/modules/useModuleAccess.ts
+++ b/components/modules/useModuleAccess.ts
@@ -14,21 +14,53 @@ export function useModuleAccess(featureKey: string) {
   const [loading, setLoading] = React.useState(true);
   const [active, setActive] = React.useState(false);
   const [enabled, setEnabled] = React.useState(false);
+  const [bankReady, setBankReady] = React.useState(true);
 
   React.useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const r = await fetch("/api/billing/subscription/status", { cache: "no-store" });
+        const orgId =
+          typeof window !== "undefined" ? window.localStorage.getItem("org_id") : null;
+
+        if (!orgId) {
+          if (!cancelled) {
+            setBankReady(false);
+            setActive(false);
+            setEnabled(false);
+          }
+          return;
+        }
+
+        const params = new URLSearchParams({ org_id: orgId });
+        const r = await fetch(`/api/billing/subscription/status?${params.toString()}`, {
+          cache: "no-store",
+        });
+        if (!r.ok) {
+          if (!cancelled) {
+            setBankReady(false);
+            setActive(false);
+            setEnabled(false);
+          }
+          return;
+        }
         const j = (await r.json()) as SubscriptionStatus;
         if (!cancelled) {
-          const subActive = !!j?.data?.active;
-          const modules = j?.data?.modules || {};
-          setActive(subActive);
-          setEnabled(!!modules[featureKey]);
+          const ok = "ok" in j ? Boolean(j.ok) : true;
+          setBankReady(ok);
+          if (ok) {
+            const subActive = !!j?.data?.active;
+            const modules = j?.data?.modules || {};
+            setActive(subActive);
+            setEnabled(!!modules[featureKey]);
+          } else {
+            setActive(false);
+            setEnabled(false);
+          }
         }
       } catch {
         if (!cancelled) {
+          setBankReady(false);
           setActive(false);
           setEnabled(false);
         }
@@ -42,5 +74,5 @@ export function useModuleAccess(featureKey: string) {
   }, [featureKey]);
 
   const locked = !(active && enabled);
-  return { loading, locked, active, enabled };
+  return { loading, locked, active, enabled, bankReady };
 }


### PR DESCRIPTION
## Summary
- permanently redirect the legacy /areas route to /especialidades for better SEO
- surface clearer locked messaging with neon CTA when modules are gated behind Sanoa Bank
- load subscription status with the active organization id and show guidance when Bank setup is missing

## Testing
- pnpm lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc60aa2b00832aa4696235131f4065