### PR TITLE
Update specialties page to require active org

### DIFF
--- a/app/(app)/especialidades/page.tsx
+++ b/app/(app)/especialidades/page.tsx
@@ -1,11 +1,13 @@
 // app/(app)/especialidades/page.tsx
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import AccentHeader from "@/components/ui/AccentHeader";
 import ColorEmoji from "@/components/ColorEmoji";
 import AnimateIn from "@/components/ui/AnimateIn";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
 
 const SPECIALTIES = [
   {
@@ -43,36 +45,101 @@ type SubscriptionStatus = {
   data?: {
     active?: boolean;
     modules?: Record<string, boolean> | null;
+    bank_ready?: boolean;
   };
+  error?: string;
 };
 
 export default function EspecialidadesPage() {
+  const { orgId, isLoading: orgLoading } = useBankActiveOrg();
   const [status, setStatus] = useState<SubscriptionStatus | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let alive = true;
+
+    if (!orgId) {
+      setStatus(null);
+      setLoading(false);
+      return () => {
+        alive = false;
+      };
+    }
+
     (async () => {
       try {
         setLoading(true);
-        const r = await fetch("/api/billing/subscription/status", { cache: "no-store" });
-        const j = await r.json();
+        const params = new URLSearchParams({ org_id: orgId });
+        const r = await fetch(`/api/billing/subscription/status?${params.toString()}`, {
+          cache: "no-store",
+        });
+        const j = (await r.json()) as SubscriptionStatus;
         if (!alive) return;
         setStatus(j);
       } catch (err) {
         if (!alive) return;
-        setStatus({ ok: true, data: { active: false, modules: {} } });
+        setStatus({ ok: false, error: (err as Error)?.message });
       } finally {
         if (alive) setLoading(false);
       }
     })();
+
     return () => {
       alive = false;
     };
-  }, []);
+  }, [orgId]);
 
-  const modules = status?.data?.modules || {};
+  const modules = useMemo(() => status?.data?.modules || {}, [status]);
   const subActive = Boolean(status?.data?.active);
+  const bankReady = Boolean(status?.data?.bank_ready);
+
+  if (orgLoading) {
+    return (
+      <main className="space-y-8">
+        <AnimateIn>
+          <AccentHeader
+            title="Especialidades Pro"
+            subtitle="Activa módulos clínicos avanzados y pruébalos en modo vista previa. Gestiona accesos desde Sanoa Bank."
+            emojiToken="carpeta"
+          />
+        </AnimateIn>
+        <div className="glass relative flex flex-col gap-3 rounded-3xl p-6 md:p-8">
+          <p className="text-sm text-[var(--color-brand-text)]/70 dark:text-slate-100/80">
+            Cargando organizaciones…
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!orgId) {
+    return (
+      <main className="space-y-8">
+        <AnimateIn>
+          <AccentHeader
+            title="Especialidades Pro"
+            subtitle="Activa módulos clínicos avanzados y pruébalos en modo vista previa. Gestiona accesos desde Sanoa Bank."
+            emojiToken="carpeta"
+          />
+        </AnimateIn>
+        <div className="glass relative flex flex-col gap-4 rounded-3xl p-6 md:p-8 max-w-xl">
+          <p className="text-base text-[var(--color-brand-text)]/80 dark:text-slate-100/90">
+            Selecciona una organización activa para continuar.
+          </p>
+          <OrgSwitcherBadge variant="inline" />
+          <Link
+            href="/organizaciones"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-[var(--color-brand-border)] bg-white/80 px-5 py-3 text-sm font-semibold text-[var(--color-brand-text)] transition hover:bg-white/95 dark:bg-slate-900/50 dark:text-slate-100 dark:hover:bg-slate-900/70"
+          >
+            Administrar organizaciones
+          </Link>
+          <p className="text-xs text-[var(--color-brand-text)]/60 dark:text-slate-100/70">
+            Tip: también puedes cambiar de organización desde la esquina superior derecha.
+          </p>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="space-y-8">
@@ -84,10 +151,17 @@ export default function EspecialidadesPage() {
         />
       </AnimateIn>
 
+      {!bankReady && (
+        <div className="rounded-3xl border border-amber-200 bg-amber-50 p-5 text-sm font-medium text-amber-800 dark:border-amber-300/60 dark:bg-amber-500/10 dark:text-amber-200">
+          Primero configura Sanoa Bank para activar estas especialidades.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-6">
         {SPECIALTIES.map((spec, idx) => {
           const enabled = Boolean(modules?.[spec.featureKey]);
-          const locked = !(subActive && enabled);
+          const locked = !(subActive && enabled && bankReady);
+          const checkoutHref = `/banco?checkout=${encodeURIComponent(spec.featureKey)}&org_id=${encodeURIComponent(orgId)}`;
           return (
             <AnimateIn key={spec.featureKey} delay={idx * 60}>
               <div className="glass relative flex h-full flex-col gap-6 rounded-3xl p-6 md:p-8">
@@ -130,10 +204,18 @@ export default function EspecialidadesPage() {
                     🚀 Abrir vista previa
                   </Link>
                   <Link
-                    href={`/banco?module=${encodeURIComponent(spec.featureKey)}`}
+                    href={checkoutHref}
                     className="inline-flex items-center gap-2 rounded-2xl border border-[var(--color-brand-border)] bg-white/80 px-5 py-3 text-base font-semibold text-[var(--color-brand-text)] transition hover:bg-white/95 dark:bg-slate-900/50 dark:text-slate-100 dark:hover:bg-slate-900/70"
                   >
-                    <span className="emoji">🏦</span> Gestionar en Bank
+                    {locked ? (
+                      <>
+                        <span className="emoji">🔓</span> Desbloquear
+                      </>
+                    ) : (
+                      <>
+                        <span className="emoji">🏦</span> Gestionar en Bank
+                      </>
+                    )}
                   </Link>
                 </div>
 

--- a/app/api/billing/subscription/status/route.ts
+++ b/app/api/billing/subscription/status/route.ts
@@ -9,10 +9,25 @@ export async function GET(req: Request) {
 
   const { data, error } = await supa
     .from("org_subscriptions")
-    .select("stripe_status, current_period_end, stripe_customer_id")
+    .select("stripe_status, current_period_end, stripe_customer_id, modules, bank_ready")
     .eq("org_id", org_id)
     .maybeSingle();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ ok: true, data: data || {} });
+  const status = data?.stripe_status ?? null;
+  const active = typeof status === "string" && ["active", "trialing", "past_due"].includes(status);
+  const modules = (data?.modules as Record<string, boolean> | null) ?? {};
+  const bankReady = Boolean((data as { bank_ready?: boolean | null } | null)?.bank_ready);
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      stripe_status: status,
+      current_period_end: data?.current_period_end ?? null,
+      stripe_customer_id: data?.stripe_customer_id ?? null,
+      active,
+      modules,
+      bank_ready: bankReady,
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- require selecting an organization before loading the specialties grid and show guidance when none is active
- surface bank readiness in the specialties view, including an unlock button that links to the bank checkout flow
- extend the subscription status API to compute active/modules/bank_ready metadata for the selected organization

## Testing
- pnpm lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6141b7b8832a9c682dc70f8de7f0