### PR TITLE
Improve Bank activations and reminder tooling

### DIFF
--- a/app/(app)/banco/page.tsx
+++ b/app/(app)/banco/page.tsx
@@ -1,74 +1,180 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import AccentHeader from "@/components/ui/AccentHeader";
 import ColorEmoji from "@/components/ColorEmoji";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
+import { useToast } from "@/components/Toast";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
+
+const MODULE_DEFS: Array<{
+  key: string;
+  label: string;
+  desc: string;
+  token: string;
+}> = [
+  {
+    key: "mente",
+    label: "Mente Pro",
+    desc: "Evaluaciones clínicas, notas SOAP y seguimiento emocional.",
+    token: "mente",
+  },
+  {
+    key: "equilibrio",
+    label: "Equilibrio Pro",
+    desc: "Planes de hábitos, ejercicios y check-ins automatizados.",
+    token: "equilibrio",
+  },
+  {
+    key: "sonrisa",
+    label: "Sonrisa Pro",
+    desc: "Odontograma digital, presupuestos y firmas electrónicas.",
+    token: "sonrisa",
+  },
+];
+
+type ModulesStatus = { active: boolean; modules: Record<string, boolean> };
 
 function cents(n: number) {
   return (n / 100).toLocaleString("es-MX", { style: "currency", currency: "MXN" });
 }
 
 export default function BancoPage() {
+  const { orgId, isLoading } = useBankActiveOrg();
+  const { toast } = useToast();
+  const [modulesStatus, setModulesStatus] = useState<ModulesStatus>({
+    active: false,
+    modules: {},
+  });
+  const [loadingModules, setLoadingModules] = useState(false);
+
+  const hasModulesInfo = useMemo(
+    () => Object.keys(modulesStatus.modules).length > 0,
+    [modulesStatus.modules],
+  );
+
+  useEffect(() => {
+    if (!orgId) {
+      setModulesStatus({ active: false, modules: {} });
+      return;
+    }
+    void refreshModules();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId]);
+
+  async function refreshModules() {
+    if (!orgId) return;
+    setLoadingModules(true);
+    try {
+      const params = new URLSearchParams({ org_id: orgId });
+      const res = await fetch(`/api/billing/subscription/status?${params.toString()}`, {
+        cache: "no-store",
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json) {
+        throw new Error(json?.error ?? "No se pudo obtener el estado de módulos");
+      }
+      setModulesStatus({
+        active: Boolean(json?.data?.active),
+        modules: (json?.data?.modules as Record<string, boolean> | undefined) ?? {},
+      });
+    } catch (error: any) {
+      toast({
+        variant: "error",
+        title: "No se pudieron cargar las activaciones",
+        description: error?.message ?? "Intenta nuevamente más tarde.",
+      });
+    } finally {
+      setLoadingModules(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="p-6 md:p-10">
+        <div className="glass-card p-6 max-w-md space-y-2">
+          <div className="h-6 w-48 rounded bg-white/50" />
+          <div className="h-4 w-64 rounded bg-white/40" />
+          <div className="h-4 w-40 rounded bg-white/40" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!orgId) {
+    return (
+      <main className="p-6 md:p-10">
+        <div className="glass-card p-6 max-w-lg space-y-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Sanoa Bank</h1>
+            <p className="text-sm text-[var(--color-brand-text)]/70">
+              Selecciona una organización activa para acceder a saldos, activaciones y reportes.
+            </p>
+          </div>
+          <OrgSwitcherBadge variant="inline" />
+          <Link
+            href="/organizaciones"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+          >
+            Administrar organizaciones
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="p-6 md:p-10 space-y-8">
       <AccentHeader
         title="Sanoa Bank"
-        subtitle="Centraliza tu saldo, depósitos, pagos y suscripciones."
+        subtitle="Centraliza tu saldo, depósitos, pagos y activaciones de módulos."
         emojiToken="banco"
       />
 
-      {/* Accesos rápidos a vistas clave */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <Link
-          href="/banco/tx"
-          className="rounded-3xl bg-white/95 border p-6 hover:shadow-sm transition"
-        >
+        <Link href="/banco/tx" className="glass-card p-6 transition hover:shadow-lg">
           <h3 className="font-semibold inline-flex items-center gap-2">
             <ColorEmoji token="banco" /> Transacciones
           </h3>
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="mt-2 text-sm text-[var(--color-brand-bluegray)]">
             Explora, filtra y exporta tus movimientos. Acciones masivas y conciliación.
           </p>
-          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm">
+          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm bg-white/60">
             Abrir tabla
           </span>
         </Link>
 
-        <Link
-          href="/banco/reglas"
-          className="rounded-3xl bg-white/95 border p-6 hover:shadow-sm transition"
-        >
+        <Link href="/banco/reglas" className="glass-card p-6 transition hover:shadow-lg">
           <h3 className="font-semibold inline-flex items-center gap-2">
             <ColorEmoji token="carpeta" /> Reglas
           </h3>
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="mt-2 text-sm text-[var(--color-brand-bluegray)]">
             Clasificación automática por texto, categoría y tags con prioridad.
           </p>
-          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm">
+          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm bg-white/60">
             Gestionar reglas
           </span>
         </Link>
 
-        <Link
-          href="/banco/presupuestos"
-          className="rounded-3xl bg-white/95 border p-6 hover:shadow-sm transition"
-        >
+        <Link href="/banco/presupuestos" className="glass-card p-6 transition hover:shadow-lg">
           <h3 className="font-semibold inline-flex items-center gap-2">
             <ColorEmoji token="plan" /> Presupuestos
           </h3>
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="mt-2 text-sm text-[var(--color-brand-bluegray)]">
             Define montos por categoría y mes para controlar desvíos.
           </p>
-          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm">
+          <span className="inline-flex mt-3 px-3 py-1.5 rounded-lg border text-sm bg-white/60">
             Configurar mes
           </span>
         </Link>
       </section>
 
-      {/* Tarjetas existentes (saldo, suscripciones, reportes) */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="rounded-3xl bg-white/95 border p-6">
+        <div className="glass-card p-6">
           <h3 className="font-semibold">Saldo</h3>
           <p className="mt-2 text-3xl tracking-tight">{cents(0)}</p>
-          <p className="text-sm text-slate-500 mt-1">
+          <p className="text-sm text-[var(--color-brand-bluegray)] mt-1">
             Disponible para compras de módulos y créditos de mensajes.
           </p>
           <div className="mt-4 flex gap-2">
@@ -80,50 +186,92 @@ export default function BancoPage() {
             </Link>
             <Link
               href="/api/billing/stripe/checkout/add-funds"
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border"
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border bg-white/70"
             >
               <ColorEmoji token="pago" /> Añadir fondos
             </Link>
           </div>
         </div>
 
-        <div className="rounded-3xl bg-white/95 border p-6">
-          <h3 className="font-semibold">Suscripciones</h3>
-          <ul className="mt-3 space-y-2 text-sm">
-            <li>🔹 Mente — activo / por activar</li>
-            <li>🔹 Pulso — activo / por activar</li>
-            <li>🔹 Sonrisa — activo / por activar</li>
-            <li>🔹 Equilibrio — activo / por activar</li>
-          </ul>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Link
-              href="/banco/ajustes"
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border"
-            >
-              <ColorEmoji token="ajustes" /> Gestionar
-            </Link>
-          </div>
-        </div>
-
-        <div className="rounded-3xl bg-white/95 border p-6">
+        <div className="glass-card p-6">
           <h3 className="font-semibold">Reportes</h3>
-          <p className="text-sm text-slate-500 mt-2">
+          <p className="text-sm text-[var(--color-brand-bluegray)] mt-2">
             Flujo mensual y P&amp;L. Programa envíos recurrentes.
           </p>
           <div className="mt-4 flex gap-2">
             <Link
               href="/banco/reportes"
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border"
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border bg-white/70"
             >
               <ColorEmoji token="reportes" /> Ver reportes
             </Link>
             <Link
               href="/api/bank/ledger/export"
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border"
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border bg-white/70"
             >
               <ColorEmoji token="exportar" /> Exportar CSV
             </Link>
           </div>
+        </div>
+
+        <div className="glass-card p-6 space-y-3">
+          <div className="flex items-start gap-3">
+            <span className="rounded-2xl p-3 border border-white/60 bg-white/70">
+              <ColorEmoji token="banco" size={24} />
+            </span>
+            <div>
+              <h3 className="font-semibold">Activaciones</h3>
+              <p className="text-sm text-[var(--color-brand-bluegray)]">
+                Estado en vivo de tus módulos Pro vinculados a la organización activa.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={refreshModules}
+            disabled={loadingModules}
+            className="inline-flex items-center gap-2 rounded-xl border border-[var(--color-brand-border)] px-3 py-2 text-sm font-medium hover:bg-white/80 disabled:opacity-60"
+          >
+            {loadingModules ? "Actualizando…" : "Actualizar estado"}
+          </button>
+          <div className="space-y-2 text-sm">
+            {MODULE_DEFS.map((module) => {
+              const active = modulesStatus.active && Boolean(modulesStatus.modules[module.key]);
+              return (
+                <div
+                  key={module.key}
+                  className="flex items-start justify-between gap-3 rounded-2xl border border-white/50 bg-white/60 px-3 py-2"
+                >
+                  <div>
+                    <div className="flex items-center gap-2 font-medium">
+                      <ColorEmoji token={module.token} /> {module.label}
+                    </div>
+                    <p className="text-xs text-[var(--color-brand-bluegray)] mt-0.5">{module.desc}</p>
+                  </div>
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${
+                      active
+                        ? "bg-emerald-100 text-emerald-800 border-emerald-200"
+                        : "bg-amber-100 text-amber-800 border-amber-200"
+                    }`}
+                  >
+                    {active ? "Activo" : "Pendiente"}
+                  </span>
+                </div>
+              );
+            })}
+
+            {!loadingModules && !hasModulesInfo && (
+              <p className="rounded-2xl border border-dashed border-white/60 bg-white/50 px-3 py-2 text-xs text-[var(--color-brand-bluegray)]">
+                Sin activaciones registradas aún. Gestiona módulos desde los ajustes de Bank.
+              </p>
+            )}
+          </div>
+          <Link
+            href="/banco/ajustes"
+            className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium hover:bg-white/80"
+          >
+            <ColorEmoji token="ajustes" /> Gestionar módulos
+          </Link>
         </div>
       </section>
     </main>

--- a/app/(app)/banco/presupuestos/page.tsx
+++ b/app/(app)/banco/presupuestos/page.tsx
@@ -1,21 +1,45 @@
 "use client";
 
-import { useMemo } from "react";
-import { getActiveOrg } from "@/lib/org-local";
+import Link from "next/link";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
 import BudgetsGrid from "@/components/bank/BudgetsGrid";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
 
 export default function BankBudgetsPage() {
-  const org = useMemo(() => getActiveOrg(), []);
-  const orgId = org?.id || "";
+  const { orgId, isLoading } = useBankActiveOrg();
+
+  if (isLoading) {
+    return (
+      <div className="p-4 md:p-6 max-w-6xl mx-auto">
+        <div className="glass-card p-6 max-w-md space-y-2">
+          <div className="h-6 w-48 rounded bg-white/50" />
+          <div className="h-4 w-64 rounded bg-white/40" />
+          <div className="h-4 w-40 rounded bg-white/40" />
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4 md:p-6 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-2">Banco · Presupuestos</h1>
+    <div className="p-4 md:p-6 max-w-6xl mx-auto space-y-6">
+      <h1 className="text-2xl font-semibold">Banco · Presupuestos</h1>
       {!orgId && (
-        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3 mb-4">
-          Selecciona una organización activa para continuar.
-        </p>
+        <div className="glass-card p-6 max-w-lg space-y-4">
+          <div>
+            <p className="text-sm text-[var(--color-brand-text)]/70">
+              Selecciona una organización activa para continuar.
+            </p>
+          </div>
+          <OrgSwitcherBadge variant="inline" />
+          <Link
+            href="/organizaciones"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+          >
+            Administrar organizaciones
+          </Link>
+        </div>
       )}
-      {orgId && <BudgetsGrid />}
+      {orgId && <BudgetsGrid orgId={orgId} />}
     </div>
   );
 }

--- a/app/(app)/banco/reportes/page.tsx
+++ b/app/(app)/banco/reportes/page.tsx
@@ -1,23 +1,35 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
+import Link from "next/link";
 import AccentHeader from "@/components/ui/AccentHeader";
 import ColorEmoji from "@/components/ColorEmoji";
-import { getActiveOrg } from "@/lib/org-local";
+import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
 import ReportFlow from "@/components/bank/ReportFlow";
 import ReportPL from "@/components/bank/ReportPL";
 import ScheduleForm from "@/components/reports/ScheduleForm";
+import { useBankActiveOrg } from "@/hooks/useBankActiveOrg";
 
 function iso(d: Date) {
   return d.toISOString().slice(0, 10);
 }
 
 export default function BankReportsPage() {
-  const org = useMemo(() => getActiveOrg(), []);
-  const orgId = org?.id || "";
-
+  const { orgId, isLoading } = useBankActiveOrg();
   const [to, setTo] = useState(iso(new Date()));
   const [from, setFrom] = useState(iso(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)));
+
+  if (isLoading) {
+    return (
+      <main className="p-6 md:p-10">
+        <div className="glass-card p-6 max-w-md space-y-2">
+          <div className="h-6 w-48 rounded bg-white/50" />
+          <div className="h-4 w-64 rounded bg-white/40" />
+          <div className="h-4 w-40 rounded bg-white/40" />
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="p-6 md:p-10 space-y-8">
@@ -28,20 +40,32 @@ export default function BankReportsPage() {
       />
 
       {!orgId && (
-        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
-          Selecciona una organización activa para continuar.
-        </p>
+        <section className="glass-card p-6 max-w-lg space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold text-[var(--color-brand-text)]">Selecciona una organización</h2>
+            <p className="text-sm text-[var(--color-brand-text)]/70">
+              Necesitas una organización activa para generar reportes financieros.
+            </p>
+          </div>
+          <OrgSwitcherBadge variant="inline" />
+          <Link
+            href="/organizaciones"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:shadow-sm"
+          >
+            Administrar organizaciones
+          </Link>
+        </section>
       )}
 
       {orgId && (
         <>
-          <section className="rounded-3xl bg-white/95 border p-6 space-y-4">
+          <section className="glass-card p-6 space-y-4">
             <div className="flex flex-wrap gap-3 items-end">
               <div>
                 <label className="block text-sm mb-1">Desde</label>
                 <input
                   type="date"
-                  className="rounded border px-3 py-2"
+                  className="glass-input"
                   value={from}
                   onChange={(e) => setFrom(e.target.value)}
                 />
@@ -50,7 +74,7 @@ export default function BankReportsPage() {
                 <label className="block text-sm mb-1">Hasta</label>
                 <input
                   type="date"
-                  className="rounded border px-3 py-2"
+                  className="glass-input"
                   value={to}
                   onChange={(e) => setTo(e.target.value)}
                 />
@@ -58,13 +82,13 @@ export default function BankReportsPage() {
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div className="rounded-2xl border p-4">
+              <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
                 <h3 className="font-semibold inline-flex items-center gap-2">
                   <ColorEmoji token="grafica" /> Flujo mensual
                 </h3>
                 <ReportFlow orgId={orgId} from={from} to={to} />
               </div>
-              <div className="rounded-2xl border p-4">
+              <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
                 <h3 className="font-semibold inline-flex items-center gap-2">
                   <ColorEmoji token="tabla" /> P&amp;L por categoría
                 </h3>
@@ -73,7 +97,7 @@ export default function BankReportsPage() {
             </div>
           </section>
 
-          <section className="rounded-3xl bg-white/95 border p-6 space-y-4">
+          <section className="glass-card p-6 space-y-4">
             <h3 className="font-semibold inline-flex items-center gap-2">
               <ColorEmoji token="recordatorios" /> Programar envío de reportes
             </h3>

--- a/app/(app)/consultorio/page.tsx
+++ b/app/(app)/consultorio/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import PatientAutocomplete from "@/components/patients/PatientAutocomplete";
 import { getActiveOrg } from "@/lib/org-local";
 
@@ -97,7 +98,7 @@ function CardLink({
   desc: string;
 }) {
   return (
-    <a href={href} className="rounded-2xl border p-4 hover:shadow-sm transition">
+    <Link href={href} className="glass-card p-4 hover:shadow-lg transition" prefetch>
       <div className="flex items-start gap-3">
         <div className="h-10 w-10 rounded-xl border inline-grid place-content-center">
           <span className="emoji">{/* opcional: ícono según token */}</span>
@@ -107,6 +108,6 @@ function CardLink({
           <p className="text-sm text-slate-600">{desc}</p>
         </div>
       </div>
-    </a>
+    </Link>
   );
 }

--- a/app/(app)/perfil/page.tsx
+++ b/app/(app)/perfil/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient, User } from "@supabase/supabase-js";
 import ColorEmoji from "@/components/ColorEmoji";
-import { useToastSafe } from "@/components/Toast";
+import { useToast } from "@/components/Toast";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -13,7 +13,7 @@ const supabase = createClient(
 
 export default function PerfilPage() {
   const router = useRouter();
-  const { toast } = useToastSafe();
+  const { toast } = useToast();
 
   const [user, setUser] = useState<User | null>(null);
   const [email, setEmail] = useState("");

--- a/app/(app)/recordatorios/page.tsx
+++ b/app/(app)/recordatorios/page.tsx
@@ -35,7 +35,7 @@ export default function RecordatoriosPage() {
       />
 
       {/* === TU SECCIÓN ORIGINAL (no se toca) === */}
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <Link
           href="/reportes/confirmaciones"
           className="rounded-3xl bg-white/95 border border-[var(--color-brand-border)] p-6 hover:shadow-lg transition"
@@ -65,6 +65,23 @@ export default function RecordatoriosPage() {
               <h3 className="text-lg font-semibold">Ajustes</h3>
               <p className="text-[var(--color-brand-bluegray)] mt-1">
                 Plantillas y canales (SMS/WhatsApp/Email).
+              </p>
+            </div>
+          </div>
+        </Link>
+
+        <Link
+          href="/recordatorios/plantillas"
+          className="rounded-3xl bg-white/95 border border-[var(--color-brand-border)] p-6 hover:shadow-lg transition"
+        >
+          <div className="flex items-start gap-4">
+            <div className="rounded-2xl p-4 border bg-[var(--color-brand-background)]">
+              <ColorEmoji token="plantilla" size={28} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Plantillas</h3>
+              <p className="text-[var(--color-brand-bluegray)] mt-1">
+                Edita textos por especialidad y haz pruebas antes de enviar.
               </p>
             </div>
           </div>

--- a/app/api/reminders/templates/upsert/route.ts
+++ b/app/api/reminders/templates/upsert/route.ts
@@ -4,7 +4,19 @@
 // Body: { org_id, name, specialty?, channel, body, variables?: string[], is_active?: boolean }
 
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getSupabaseServer } from "@/lib/supabase/server";
+import { parseOrError } from "@/lib/http/validate";
+
+const UpsertSchema = z.object({
+  org_id: z.string().min(1, "org_id requerido"),
+  name: z.string().trim().min(1, "name requerido"),
+  specialty: z.string().trim().optional().nullable(),
+  channel: z.enum(["sms", "whatsapp"]),
+  body: z.string().min(1, "body requerido"),
+  variables: z.array(z.string()).optional(),
+  is_active: z.boolean().optional(),
+});
 
 export async function POST(req: NextRequest) {
   try {
@@ -20,47 +32,29 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json().catch(() => ({}));
-    const org_id: string | undefined = body?.org_id;
-    const name: string = (body?.name ?? "").trim();
-    const specialty: string | null = body?.specialty ? String(body.specialty) : null;
-    const channel: "sms" | "whatsapp" = (body?.channel ?? "").trim();
-    const tplBody: string = (body?.body ?? "").toString();
-
-    const variables: string[] = Array.isArray(body?.variables)
-      ? Array.from(new Set(body.variables.map((s: any) => String(s).trim()).filter(Boolean)))
-      : [];
-
-    const is_active: boolean = Boolean(body?.is_active ?? true);
-
-    // Requeridos
-    if (!org_id || !name || !channel || !tplBody) {
+    const parsed = parseOrError(UpsertSchema, body);
+    if (!parsed.ok)
       return NextResponse.json(
-        {
-          ok: false,
-          error: { code: "BAD_REQUEST", message: "org_id, name, channel y body son requeridos" },
-        },
+        { ok: false, error: { code: "VALIDATION_ERROR", message: parsed.error.message } },
         { status: 400 },
       );
-    }
-    if (!["sms", "whatsapp"].includes(channel)) {
-      return NextResponse.json(
-        { ok: false, error: { code: "BAD_REQUEST", message: "channel inválido" } },
-        { status: 400 },
-      );
-    }
+
+    const variables = Array.from(
+      new Set((parsed.data.variables ?? []).map((s) => s.trim()).filter(Boolean)),
+    );
 
     // Upsert por (org_id, name)
     const { data, error } = await supa
       .from("reminders_templates") // 👈 nota: nombre de tabla en plural
       .upsert(
         {
-          org_id,
-          name,
-          specialty,
-          channel,
-          body: tplBody,
+          org_id: parsed.data.org_id,
+          name: parsed.data.name,
+          specialty: parsed.data.specialty ?? null,
+          channel: parsed.data.channel,
+          body: parsed.data.body,
           variables,
-          is_active,
+          is_active: parsed.data.is_active ?? true,
           updated_by: u.user.id,
           created_by: u.user.id,
         },

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,7 +6,7 @@ import { Suspense, useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { ThemeProvider } from "next-themes";
 import { ToastProvider } from "@/components/Toast";
-import Toaster from "@/components/Toaster";
+import { Toaster } from "@/components/Toaster";
 
 // ---- Segment Loader (analytics.js) ----
 declare global {
@@ -99,14 +99,14 @@ function QueryParamsBridge() {
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <ToastProvider>
+    <ToastProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <Suspense fallback={null}>
           <QueryParamsBridge />
         </Suspense>
         {children}
-        <Toaster />
-      </ToastProvider>
-    </ThemeProvider>
+      </ThemeProvider>
+      <Toaster />
+    </ToastProvider>
   );
 }

--- a/components/Toaster.tsx
+++ b/components/Toaster.tsx
@@ -35,7 +35,7 @@ export function showToast(
   } catch {}
 }
 
-export default function Toaster() {
+export function Toaster() {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   useEffect(() => {
@@ -79,3 +79,5 @@ export default function Toaster() {
     </div>
   );
 }
+
+export default Toaster;


### PR DESCRIPTION
## Summary
- wrap the app with the Toast provider/Toaster pairing so client hooks work in Perfil and beyond
- refresh the Bank experience with the shared org hook, activation status cards, glass styling, and consistent budgets/report handling
- harden reminder templates with toast feedback, a direct link to plantillas, and Zod-backed preview/upsert APIs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc6183e3c4832a9ff04330cada896c