### PR TITLE
Fix ESLint flat config compatibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,153 @@
 // eslint.config.mjs
-import js from "@eslint/js";
-import next from "eslint-config-next";
-import ts from "typescript-eslint";
+import { existsSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { FlatCompat } from "@eslint/eslintrc";
+import tseslint from "typescript-eslint";
+
+const require = createRequire(import.meta.url);
+
+const loadFromPnpm = (specifier) => {
+  try {
+    return require(specifier);
+  } catch (initialError) {
+    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const pnpmDir = join(baseDir, "node_modules", ".pnpm");
+
+    if (!existsSync(pnpmDir)) {
+      throw initialError;
+    }
+
+    const parts = specifier.split("/");
+    const prefix = specifier.startsWith("@")
+      ? `${parts[0]}+${parts[1]}@`
+      : `${specifier}@`;
+
+    const matchedEntry = readdirSync(pnpmDir).find((entry) =>
+      entry.startsWith(prefix),
+    );
+
+    if (!matchedEntry) {
+      throw initialError;
+    }
+
+    const packagePath = join(pnpmDir, matchedEntry, "node_modules", ...parts);
+    return require(packagePath);
+  }
+};
+
+const resolveFromPnpm = (specifier) => {
+  try {
+    return require.resolve(specifier);
+  } catch (initialError) {
+    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const pnpmDir = join(baseDir, "node_modules", ".pnpm");
+
+    if (!existsSync(pnpmDir)) {
+      throw initialError;
+    }
+
+    const parts = specifier.split("/");
+    const prefix = specifier.startsWith("@")
+      ? `${parts[0]}+${parts[1]}@`
+      : `${specifier}@`;
+
+    const matchedEntry = readdirSync(pnpmDir).find((entry) =>
+      entry.startsWith(prefix),
+    );
+
+    if (!matchedEntry) {
+      throw initialError;
+    }
+
+    return join(pnpmDir, matchedEntry, "node_modules", ...parts);
+  }
+};
+
+const js = loadFromPnpm("@eslint/js");
+const globals = loadFromPnpm("globals");
+const importPlugin = loadFromPnpm("eslint-plugin-import");
+const reactPlugin = loadFromPnpm("eslint-plugin-react");
+const reactHooksPlugin = loadFromPnpm("eslint-plugin-react-hooks");
+const jsxA11yPlugin = loadFromPnpm("eslint-plugin-jsx-a11y");
+const nextPlugin = loadFromPnpm("@next/eslint-plugin-next");
+const tsParserPath = resolveFromPnpm("@typescript-eslint/parser");
+const importResolverNodePath = resolveFromPnpm("eslint-import-resolver-node");
+const importResolverTsPath = resolveFromPnpm("eslint-import-resolver-typescript");
+
+const compat = new FlatCompat({
+  baseDirectory: dirname(fileURLToPath(import.meta.url)),
+});
+
+const nextConfigs = [
+  ...compat.extends("plugin:react/recommended"),
+  ...compat.extends("plugin:react-hooks/recommended"),
+  ...compat.extends("plugin:@next/next/recommended"),
+];
 
 export default [
-  { ignores: ["node_modules/**", ".next/**", "dist/**"] },
-  js.configs.recommended,
-  ...ts.configs.recommended,
-  ...next,
   {
+    ignores: ["**/.next/**", "dist/**", "build/**", "node_modules/**"],
+  },
+  js.configs.recommended,
+  ...nextConfigs,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      import: importPlugin,
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+      "jsx-a11y": jsxA11yPlugin,
+      "@next/next": nextPlugin,
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+      "import/parsers": {
+        [tsParserPath]: [".ts", ".mts", ".cts", ".tsx", ".d.ts"],
+      },
+      "import/resolver": {
+        [importResolverNodePath]: {
+          extensions: [".js", ".jsx", ".ts", ".tsx"],
+        },
+        [importResolverTsPath]: {
+          alwaysTryTypes: true,
+          project: ["./tsconfig.json"],
+        },
+      },
+    },
     rules: {
-      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "react-hooks/exhaustive-deps": "off",
+      "import/no-anonymous-default-export": "warn",
+      "react/no-unknown-property": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off",
+      "jsx-a11y/alt-text": [
+        "warn",
+        {
+          elements: ["img"],
+          img: ["Image"],
+        },
+      ],
+      "jsx-a11y/aria-props": "warn",
+      "jsx-a11y/aria-proptypes": "warn",
+      "jsx-a11y/aria-unsupported-elements": "warn",
+      "jsx-a11y/role-has-required-aria-props": "warn",
+      "jsx-a11y/role-supports-aria-props": "warn",
+      "react/jsx-no-target-blank": "off",
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@eslint/js": "^9.35.0",
     "@next/eslint-plugin-next": "15.5.3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20.19.13",
@@ -54,6 +55,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^14.0.0",
     "prettier": "^3.6.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@eslint/js':
+        specifier: ^9.35.0
+        version: 9.35.0
       '@next/eslint-plugin-next':
         specifier: 15.5.3
         version: 15.5.3
@@ -117,6 +120,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.35.0(jiti@2.5.1))
+      globals:
+        specifier: ^14.0.0
+        version: 14.0.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2


### PR DESCRIPTION
## Summary
- refactor the flat ESLint config to load Next.js, React, and import plugin rules with FlatCompat while setting shared browser/node globals
- add pnpm-aware helpers so @eslint/js, globals, and related plugins resolve even when pnpm does not create top-level symlinks
- declare @eslint/js and globals as dev dependencies to keep the workspace configuration explicit

## Testing
- pnpm lint *(fails: existing project lint violations such as many `@typescript-eslint/no-explicit-any` reports)*

------
https://chatgpt.com/codex/tasks/task_e_68dc62be1274832ab4fb21400d5c6a0c