### PR TITLE
Fix CI to use pnpm for dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,22 +30,27 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
       - name: Install deps
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       # (Opcional) Typecheck si tienes TS
       - name: Typecheck
-        run: npx tsc --noEmit || true
+        run: pnpm exec tsc --noEmit || true
 
       # (Opcional) Lint si tienes script
       - name: Lint
-        run: npm run lint || true
+        run: pnpm run lint || true
 
       # Build: con withSentryConfig y SENTRY_* definidos, sube sourcemaps ocultos
       - name: Build
-        run: npm run build
+        run: pnpm run build
 
       # Publica artefacto de build para debug (opcional)
       - name: Upload .next artifact


### PR DESCRIPTION
## Summary
- configure the CI workflow to install pnpm and use the pnpm lockfile
- run typecheck, lint, and build scripts via pnpm to match the project setup

## Testing
- pnpm install --frozen-lockfile
- pnpm run lint *(fails: missing @eslint/js dependency in project)*

------
https://chatgpt.com/codex/tasks/task_e_68dc63a20ab4832aba0152ed0b1fde36