### PR TITLE
feat: refresh glass aesthetic utilities

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -117,7 +117,20 @@
    ======================= */
 html {
   min-height: 100%;
-  font-size: 17px;
+  font-size: 16px;
+}
+
+@media (min-width: 640px) {
+  html {
+    font-size: 17px;
+  }
+}
+
+.emoji {
+  font-size: 1.25em;
+  line-height: 1;
+  display: inline-block;
+  transform: translateY(1px);
 }
 
 body {
@@ -129,7 +142,10 @@ body {
 }
 
 body {
-  background-image: linear-gradient(135deg, #f8fafc, #f1f5f9);
+  background:
+    radial-gradient(1200px 600px at 10% -10%, rgba(59, 130, 246, 0.15), transparent 60%),
+    radial-gradient(1200px 600px at 110% 10%, rgba(16, 185, 129, 0.14), transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.6));
   color: #1f2937;
   font-family: var(--font-body);
   line-height: 1.6;
@@ -138,7 +154,10 @@ body {
 }
 
 .dark body {
-  background-image: linear-gradient(135deg, #020617, #0f172a);
+  background:
+    radial-gradient(1200px 600px at 10% -10%, rgba(59, 130, 246, 0.2), transparent 60%),
+    radial-gradient(1200px 600px at 110% 10%, rgba(16, 185, 129, 0.18), transparent 60%),
+    linear-gradient(180deg, rgba(10, 10, 12, 0.85), rgba(10, 10, 12, 0.9));
   color: #f1f5f9;
 }
 
@@ -182,6 +201,14 @@ button {
 .surface-light {
   --color-brand-text: #0f172a;
   color: var(--color-brand-text);
+}
+
+.text-contrast {
+  color: #334155;
+}
+
+.dark .text-contrast {
+  color: #e2e8f0;
 }
 
 /* =======================
@@ -238,6 +265,38 @@ button {
 }
 .card-body {
   padding: 1.5rem;
+}
+
+.glass-card {
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 10px 30px rgba(2, 6, 23, 0.08);
+  backdrop-filter: blur(14px) saturate(130%);
+  -webkit-backdrop-filter: blur(14px) saturate(130%);
+  padding: 16px;
+}
+
+.dark .glass-card {
+  background: rgba(15, 23, 42, 0.45);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+}
+
+.glass-card input,
+.glass-card select,
+.glass-card textarea {
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.dark .glass-card input,
+.dark .glass-card select,
+.dark .glass-card textarea {
+  color: #e2e8f0;
+  background: rgba(17, 24, 39, 0.6);
+  border-color: rgba(255, 255, 255, 0.08);
 }
 
 /* =======================
@@ -309,6 +368,32 @@ button {
 .btn:not(:disabled):hover {
   transform: translateY(-1px) scale(1.01);
   box-shadow: 0 16px 38px rgba(15, 23, 42, 0.2);
+}
+
+.glass-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 14px;
+  padding: 0.6rem 0.9rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(10px) saturate(120%);
+  -webkit-backdrop-filter: blur(10px) saturate(120%);
+}
+
+.glass-btn:hover {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.dark .glass-btn {
+  background: rgba(17, 24, 39, 0.55);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .glass-btn:hover {
+  background: rgba(17, 24, 39, 0.7);
 }
 
 .btn-primary {
@@ -475,8 +560,6 @@ button {
 
 @layer components {
   .glass,
-  .glass-card,
-  .glass-btn,
   .glass-input {
     border-radius: 1rem;
     border: 1px solid rgba(var(--glass-stroke));
@@ -491,61 +574,12 @@ button {
     padding: 1.25rem;
   }
 
-  .glass-card {
-    padding: 1.25rem;
-  }
-
-  @media (min-width: 768px) {
-    .glass-card {
-      padding: 1.5rem;
-    }
-  }
-
-  .glass-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.65rem 1.25rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    gap: 0.5rem;
-  }
-
-  .glass-btn:hover {
-    transform: scale(1.01);
-  }
-
-  .glass-btn:active {
-    transform: scale(0.99);
-  }
-
-  .glass-btn:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
-  }
-
-  .glass-btn:disabled {
-    opacity: 0.5;
-    pointer-events: none;
-  }
-
   .glass-input {
     padding: 0.5rem 0.75rem;
   }
 }
 
 @layer utilities {
-  .text-contrast {
-    @apply text-slate-700 dark:text-slate-200;
-  }
-
-  .emoji {
-    font-size: 1.2em;
-    line-height: 1;
-    display: inline-block;
-    transform: translateY(1px);
-  }
-
   .glass-subtle {
     background: rgba(255, 255, 255, 0.35);
     border: 1px solid rgba(255, 255, 255, 0.25);
@@ -578,26 +612,15 @@ button {
   }
 }
 
-/* Burbuja: más blur y sombra suave */
 .bubble {
-  border-radius: 1rem;
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  box-shadow: var(--glass-shadow);
-  background: rgba(var(--glass-bg));
-  border: 1px solid rgba(var(--glass-stroke));
+  border-radius: 22px;
 }
 
-/* Neón suave: resalta acciones primarias */
 .neon {
-  position: relative;
+  box-shadow: 0 0 0 rgba(16, 185, 129, 0);
+  transition: box-shadow 0.2s ease;
 }
 
-.neon::after {
-  content: "";
-  position: absolute;
-  inset: -2px;
-  border-radius: 1.1rem;
-  pointer-events: none;
-  box-shadow: 0 0 20px rgba(56, 189, 248, 0.35);
+.neon:hover {
+  box-shadow: 0 8px 32px rgba(16, 185, 129, 0.35);
 }


### PR DESCRIPTION
## Summary
- lighten the global typography scale and apply the new glass-inspired background gradients
- add refreshed glass card, button, neon, and text contrast utilities for light and dark themes
- ensure inputs inside glass cards keep proper contrast in dark mode and enlarge emoji rendering

## Testing
- pnpm lint *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd41210954832a93ac587e1a357b5d