### PR TITLE
Add UI for prescriptions templates page

### DIFF
--- a/app/(app)/prescriptions/templates/page.tsx
+++ b/app/(app)/prescriptions/templates/page.tsx
@@ -1,20 +1,41 @@
-"use client";
+import Link from "next/link";
 
-import RequireAuth from "@/components/RequireAuth";
-import AccentHeader from "@/components/ui/AccentHeader";
-import PrescriptionEditor from "@/components/prescriptions/PrescriptionEditor";
+async function getTemplates() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL ?? ""}/api/prescriptions/templates`, { cache: "no-store" });
+  if (!res.ok) return [];
+  const json = await res.json();
+  return Array.isArray(json?.data) ? json.data : [];
+}
 
-export default function Page() {
+export default async function Page() {
+  const items = await getTemplates();
   return (
-    <RequireAuth>
-      <main className="space-y-8">
-        <AccentHeader
-          title="Plantillas de recetas"
-          subtitle="Guarda combinaciones frecuentes y emite recetas listas para imprimir en segundos."
-          emojiToken="recetas"
-        />
-        <PrescriptionEditor />
-      </main>
-    </RequireAuth>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold"><span className="emoji">💊</span> Plantillas de receta</h1>
+
+      <div className="glass-card">
+        <div className="flex items-center justify-between">
+          <p className="text-contrast text-sm">Crea y reutiliza tus plantillas de receta.</p>
+          <Link href="/prescriptions/new" className="glass-btn"><span className="emoji">➕</span> Nueva</Link>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map((t: any) => (
+          <div key={t.id} className="glass-card bubble">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="font-semibold">{t.name ?? "Sin título"}</h3>
+                <p className="text-sm text-contrast">{t.note ?? ""}</p>
+              </div>
+              <Link href={`/prescriptions/from-template?id=${t.id}`} className="glass-btn">
+                <span className="emoji">🧾</span> Usar
+              </Link>
+            </div>
+          </div>
+        ))}
+        {items.length === 0 && <div className="glass-card">Aún no tienes plantillas.</div>}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the prescriptions templates page with a server component that lists templates from the API
- add actions to create new prescriptions and use an existing template

## Testing
- pnpm lint *(fails: cannot download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd41eac308832a8e04b45c0551ddbd