### PR TITLE
Add organization switcher prompts to bank pages

### DIFF
--- a/app/(app)/banco/reglas/page.tsx
+++ b/app/(app)/banco/reglas/page.tsx
@@ -53,7 +53,14 @@ export default function BankRulesPage() {
 
   return (
     <div className="mx-auto max-w-6xl p-4 md:p-6">
-      <h1 className="mb-3 text-3xl font-semibold tracking-tight">Banco · Reglas</h1>
+      <div className="glass-card">
+        <p className="text-contrast">Selecciona una organización activa para continuar.</p>
+        <div className="mt-2">
+          <OrgSwitcherBadge />
+        </div>
+      </div>
+
+      <h1 className="mt-6 mb-3 text-3xl font-semibold tracking-tight">Banco · Reglas</h1>
       <RulesEditor />
     </div>
   );

--- a/app/(app)/banco/tx/page.tsx
+++ b/app/(app)/banco/tx/page.tsx
@@ -65,7 +65,14 @@ export default function BankTxPage() {
 
   return (
     <div className="mx-auto max-w-6xl p-4 md:p-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="glass-card">
+        <p className="text-contrast">Selecciona una organización activa para continuar.</p>
+        <div className="mt-2">
+          <OrgSwitcherBadge />
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-3xl font-semibold tracking-tight">Banco · Transacciones</h1>
         <a
           href={exportHref}


### PR DESCRIPTION
## Summary
- add an organization reminder header with the OrgSwitcherBadge to the bank transactions page
- add the same header to the bank rules page so switching organizations is more discoverable

## Testing
- pnpm lint *(fails: exits with existing warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dd428f1764832ab5f1e3e42635cda3