### PR TITLE
Implement Stripe checkout and webhook for bank features

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,45 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { createServiceClient } from "@/lib/supabase/service";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" });
+
+export async function POST(req: NextRequest) {
+  const sig = req.headers.get("stripe-signature");
+  if (!sig) return NextResponse.json({ error: "Missing signature" }, { status: 400 });
+
+  const secret = process.env.STRIPE_WEBHOOK_SECRET!;
+  let event: Stripe.Event;
+
+  try {
+    const raw = await req.text();
+    event = stripe.webhooks.constructEvent(raw, sig, secret);
+  } catch (e: any) {
+    return NextResponse.json({ error: `Invalid signature: ${e.message}` }, { status: 400 });
+  }
+
+  try {
+    if (event.type === "checkout.session.completed") {
+      const cs = event.data.object as Stripe.Checkout.Session;
+      const org_id = cs.metadata?.org_id;
+      const product = cs.metadata?.product as
+        | "mente"
+        | "pulso"
+        | "sonrisa"
+        | "equilibrio"
+        | undefined;
+      if (org_id && product) {
+        const supa = createServiceClient();
+        await supa.from("org_features").upsert(
+          { org_id, [product]: true },
+          { onConflict: "org_id" }
+        );
+      }
+    }
+    return NextResponse.json({ received: true });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "server_error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- update the bank checkout endpoint to create Stripe sessions with product metadata and configurable return paths
- add a Stripe webhook endpoint that validates signatures and activates purchased bank features in the org_features table

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated pages such as app/(app)/banco/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd47d1a6fc832a881041e09b02cd90