### PR TITLE
Handle banco checkout deeplink and update org prompts

### DIFF
--- a/app/(app)/banco/reglas/page.tsx
+++ b/app/(app)/banco/reglas/page.tsx
@@ -53,8 +53,10 @@ export default function BankRulesPage() {
 
   return (
     <div className="mx-auto max-w-6xl p-4 md:p-6">
-      <div className="glass-card">
-        <p className="text-contrast">Selecciona una organización activa para continuar.</p>
+      <div className="glass-card bubble">
+        <p className="text-contrast">
+          <span className="emoji">🏷️</span> Selecciona una organización activa para continuar.
+        </p>
         <div className="mt-2">
           <OrgSwitcherBadge />
         </div>

--- a/app/(app)/banco/tx/page.tsx
+++ b/app/(app)/banco/tx/page.tsx
@@ -65,8 +65,10 @@ export default function BankTxPage() {
 
   return (
     <div className="mx-auto max-w-6xl p-4 md:p-6">
-      <div className="glass-card">
-        <p className="text-contrast">Selecciona una organización activa para continuar.</p>
+      <div className="glass-card bubble">
+        <p className="text-contrast">
+          <span className="emoji">🏷️</span> Selecciona una organización activa para continuar.
+        </p>
         <div className="mt-2">
           <OrgSwitcherBadge />
         </div>


### PR DESCRIPTION
## Summary
- update the Banco landing page to process checkout deep links using the new product payload and return path
- memoize the module refresh helper to avoid disabling lint rules
- refresh the Banco transactions and rules screens with the new organization selection bubble prompt

## Testing
- pnpm lint *(fails: existing repository warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68dd47e979a8832a891221a58ae13b53