### PR TITLE
Add Stripe portal endpoint and bank page button

### DIFF
--- a/app/(app)/banco/page.tsx
+++ b/app/(app)/banco/page.tsx
@@ -68,8 +68,6 @@ export default function BancoPage() {
     [modulesStatus.modules],
   );
 
-  const customerId = ""; // TODO: traer de tu org (p. ej. orgs.customer_id)
-
   // Handle deep-link to checkout
   useEffect(() => {
     if (!orgId) return;
@@ -213,35 +211,6 @@ export default function BancoPage() {
     );
   }
 
-  async function handleManageSubscription() {
-    if (!customerId) {
-      alert("Aún no hay customer_id vinculado.");
-      return;
-    }
-
-    try {
-      setLoadingPortal(true);
-      const res = await fetch("/api/bank/customer-portal", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ customer_id: customerId }),
-      });
-      const json = await res.json().catch(() => null);
-      if (!res.ok || !json?.url) {
-        throw new Error(json?.error ?? "No se pudo abrir el portal del cliente.");
-      }
-      window.location.href = json.url as string;
-    } catch (error: any) {
-      toast({
-        variant: "error",
-        title: "No se pudo abrir la suscripción",
-        description: error?.message ?? "Intenta nuevamente más tarde.",
-      });
-    } finally {
-      setLoadingPortal(false);
-    }
-  }
-
   return (
     <main className="p-6 md:p-10 space-y-8">
       <AccentHeader
@@ -254,10 +223,38 @@ export default function BancoPage() {
       <div className="mt-3 flex flex-wrap gap-2">
         <button
           className="glass-btn"
-          disabled={loadingPortal || !customerId}
-          onClick={() => void handleManageSubscription()}
+          title="Administrar suscripciones"
+          disabled={loadingPortal || !orgId}
+          onClick={async () => {
+            if (loadingPortal) {
+              return;
+            }
+            const org_id = orgId;
+            if (!org_id) return;
+            try {
+              setLoadingPortal(true);
+              const r = await fetch("/api/bank/portal", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ org_id, return_path: "/banco" }),
+              });
+              const j = await r.json().catch(() => null);
+              if (!r.ok || !j?.url) {
+                throw new Error(j?.error ?? "No se pudo abrir el portal del cliente.");
+              }
+              window.location.href = j.url as string;
+            } catch (error: any) {
+              toast({
+                variant: "error",
+                title: "No se pudo abrir la suscripción",
+                description: error?.message ?? "Intenta nuevamente más tarde.",
+              });
+            } finally {
+              setLoadingPortal(false);
+            }
+          }}
         >
-          <span className="emoji">⚙️</span> {loadingPortal ? "Abriendo…" : "Gestionar suscripción"}
+          <span className="emoji">🧰</span> {loadingPortal ? "Abriendo…" : "Portal de suscripción"}
         </button>
       </div>
 

--- a/app/api/bank/portal/route.ts
+++ b/app/api/bank/portal/route.ts
@@ -1,0 +1,44 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { z } from "zod";
+
+import { createServiceClient } from "@/lib/supabase/service";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" });
+
+const Body = z.object({
+  org_id: z.string().uuid(),
+  return_path: z.string().default("/banco"),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const { org_id, return_path } = Body.parse(await req.json());
+
+    const supa = createServiceClient();
+    const { data, error } = await supa
+      .from("org_billing")
+      .select("stripe_customer_id")
+      .eq("org_id", org_id)
+      .single();
+
+    if (error || !data?.stripe_customer_id) {
+      return NextResponse.json(
+        { error: "No hay customer vinculado a esta organización" },
+        { status: 400 },
+      );
+    }
+
+    const base = process.env.NEXT_PUBLIC_SITE_URL ?? req.nextUrl.origin;
+    const sess = await stripe.billingPortal.sessions.create({
+      customer: data.stripe_customer_id,
+      return_url: `${base}${return_path}`,
+    });
+
+    return NextResponse.json({ url: sess.url });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "server_error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add a bank portal API route that looks up the organization billing record and opens a Stripe billing portal session
- wire the banco page button to call the new endpoint with the active organization and redirect to the returned portal URL

## Testing
- pnpm lint *(fails: existing error in components/RequireAuth.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd49f51b28832a9c795a498ace0c3e