### PR TITLE
Add rewrite for Spanish agreements API alias

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -91,6 +91,12 @@ const nextConfig = {
 
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
+  },
+
+  async rewrites() {
+    return [
+      { source: "/api/acuerdos/:path*", destination: "/api/agreements/:path*" }
+    ];
   }
 };
 


### PR DESCRIPTION
## Summary
- add a Next.js rewrite to serve Spanish /api/acuerdos requests from the existing agreements API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6f1aec30832aa3a66bc6fdac7737