### PR TITLE
Fix toast provider usage across app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import Providers from "./providers";
+import AppShell from "@/components/AppShell";
 
 const bodyClass =
   "font-body text-[var(--color-brand-text)] min-h-dvh antialiased bg-[length:100%_100%]";
@@ -23,10 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="es" suppressHydrationWarning>
       <body className={bodyClass}>
         <Providers>
-          {/* Nodo para portales de toasts */}
-          <div id="toast-root" />
-          {/* Contenido de la aplicación */}
-          {children}
+          <AppShell>{children}</AppShell>
         </Providers>
       </body>
     </html>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,7 +6,7 @@ import { Suspense, useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { ThemeProvider } from "next-themes";
 import { ToastProvider } from "@/components/Toast";
-import { Toaster } from "@/components/Toaster";
+import Toaster from "@/components/Toaster";
 
 // ---- Segment Loader (analytics.js) ----
 declare global {

--- a/components/Toaster.tsx
+++ b/components/Toaster.tsx
@@ -1,83 +1,37 @@
 "use client";
-import { useEffect, useState } from "react";
 
-type ToastKind = "success" | "error" | "info";
-type Toast = { id: number; message: string; kind: ToastKind };
+import { useToast } from "./Toast";
 
-let _id = 0;
+export { showToast } from "./Toast";
 
-/** showToast("msg","success")  o  showToast({ title, description, variant }) */
-export function showToast(
-  a:
-    | string
-    | {
-        title?: string;
-        description?: string;
-        variant?: "success" | "error" | "info" | "destructive";
-      },
-  kind?: ToastKind,
-) {
-  try {
-    let message = "";
-    let k: ToastKind = kind ?? "info";
+export default function Toaster() {
+  const { toasts, remove } = useToast();
 
-    if (typeof a === "string") {
-      message = a;
-    } else {
-      const title = a.title ?? "";
-      const desc = a.description ?? "";
-      message = [title, desc].filter(Boolean).join(" — ");
-      const v = a.variant ?? "info";
-      k = v === "destructive" ? "error" : (v as ToastKind);
-    }
-
-    window.dispatchEvent(new CustomEvent("sanoa:toast", { detail: { message, kind: k } }));
-  } catch {}
-}
-
-export function Toaster() {
-  const [toasts, setToasts] = useState<Toast[]>([]);
-
-  useEffect(() => {
-    function onToast(e: Event) {
-      const ce = e as CustomEvent<{ message: string; kind: ToastKind }>;
-      const t: Toast = { id: ++_id, message: ce.detail.message, kind: ce.detail.kind || "info" };
-      setToasts((prev) => [...prev, t]);
-      setTimeout(() => setToasts((prev) => prev.filter((x) => x.id !== t.id)), 4000);
-    }
-    window.addEventListener("sanoa:toast", onToast as EventListener);
-    return () => window.removeEventListener("sanoa:toast", onToast as EventListener);
-  }, []);
-
-  if (toasts.length === 0) return null;
+  if (toasts.length === 0) {
+    return null;
+  }
 
   return (
-    <div className="pointer-events-none fixed top-4 right-4 z-[100] flex w-full max-w-sm flex-col gap-2">
-      {toasts.map((t) => {
-        const base = "pointer-events-auto rounded-xl border px-4 py-3 shadow bg-white";
-        const border =
-          t.kind === "success"
-            ? "border-emerald-300"
-            : t.kind === "error"
-              ? "border-red-300"
-              : "border-[var(--color-brand-border)]";
-        const dot =
-          t.kind === "success"
-            ? "bg-emerald-500"
-            : t.kind === "error"
-              ? "bg-red-500"
-              : "bg-[var(--color-brand-coral)]";
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {toasts.map((toast) => {
+        const variant = toast.variant === "error" ? "error" : toast.variant === "success" ? "success" : "default";
+        const emoji = variant === "success" ? "✅" : variant === "error" ? "⚠️" : "🔔";
+
         return (
-          <div key={t.id} className={`${base} ${border}`}>
-            <div className="flex items-start gap-3">
-              <span className={`mt-1 inline-block h-2 w-2 rounded-full ${dot}`} />
-              <p className="text-[var(--color-brand-text)] text-sm">{t.message}</p>
+          <div key={toast.id} className="glass-card bubble min-w-[260px] flex items-start gap-2">
+            <div className="text-xl">
+              <span className="emoji">{emoji}</span>
             </div>
+            <div className="flex-1">
+              {toast.title && <div className="font-semibold">{toast.title}</div>}
+              {toast.description && <div className="text-sm text-contrast/80">{toast.description}</div>}
+            </div>
+            <button className="glass-btn" onClick={() => remove(toast.id)} aria-label="Cerrar">
+              ✖️
+            </button>
           </div>
         );
       })}
     </div>
   );
 }
-
-export default Toaster;


### PR DESCRIPTION
## Summary
- replace the toast context with a lightweight provider that tracks open toasts and exposes safe helpers
- render the toaster UI from context data and re-export `showToast` for existing callers
- ensure the application layout wraps children with the toast provider and `AppShell`

## Testing
- pnpm exec eslint app/layout.tsx app/providers.tsx components/Toast.tsx components/Toaster.tsx
- pnpm lint *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6fa11cf8832a87f59702b7f10e02