### PR TITLE
Add navbar organization switcher

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
+import OrgSwitcher from "@/components/OrgSwitcher";
 import { useToastSafe } from "@/components/Toast";
 import { getSupabaseBrowser } from "@/lib/supabase-browser";
 import { cn } from "@/lib/utils";
@@ -58,20 +59,24 @@ export default function Navbar() {
   return (
     <header className="sticky top-0 z-50 px-3 py-4 sm:px-5">
       <div className="mx-auto max-w-6xl">
-        <div className="glass bubble relative flex items-center gap-3 px-5 py-4">
-          {/* Brand */}
-          <Link
-            href="/dashboard"
-            className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-white dark:focus-visible:ring-offset-slate-900 md:text-xl"
-            aria-label="Ir al dashboard"
-          >
-            <span className="emoji">✨</span>
-            <span>Sanoa</span>
-          </Link>
+        <div className="glass bubble relative flex flex-wrap items-center gap-3 px-5 py-4">
+          <div className="flex items-center gap-3">
+            {/* Brand */}
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-white dark:focus-visible:ring-offset-slate-900 md:text-xl"
+              aria-label="Ir al dashboard"
+            >
+              <span className="emoji">✨</span>
+              <span>Sanoa</span>
+            </Link>
+
+            <OrgSwitcher />
+          </div>
 
           {/* Main nav */}
           <nav
-            className="ml-4 flex min-w-0 flex-1 items-center gap-2 overflow-x-auto whitespace-nowrap"
+            className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto whitespace-nowrap sm:ml-2"
             aria-label="Secciones principales"
           >
             {NAV.map((item) => {

--- a/components/OrgSwitcher.tsx
+++ b/components/OrgSwitcher.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { useActiveOrg } from "@/hooks/useActiveOrg";
+import { listMyOrgs, type MyOrg } from "@/lib/org";
+import { cn } from "@/lib/utils";
+
+type OrgItem = { id: string; name: string; slug?: string };
+
+function normalize(item: MyOrg): OrgItem {
+  return {
+    id: item.id,
+    name: item.is_personal ? "Personal" : item.name,
+    slug: item.slug ?? undefined,
+  };
+}
+
+export default function OrgSwitcher() {
+  const { org, loading, setActive } = useActiveOrg();
+  const [items, setItems] = useState<OrgItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setFetching(true);
+
+    (async () => {
+      try {
+        const list = await listMyOrgs();
+        if (!mounted) return;
+        const mapped = list.map(normalize);
+        setItems(mapped);
+        setError(null);
+      } catch (err) {
+        if (!mounted) return;
+        setItems([]);
+        setError("No se pudieron cargar las organizaciones.");
+      } finally {
+        if (mounted) setFetching(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  function onPick(item: OrgItem) {
+    setActive(item);
+    setOpen(false);
+  }
+
+  const label = (() => {
+    if (org) return org.name;
+    if (fetching || loading) return "Cargando organización…";
+    return "Elige organización";
+  })();
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        type="button"
+        className="glass-btn inline-flex items-center gap-2"
+        onClick={() => setOpen((value) => !value)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={loading && !org}
+      >
+        <span aria-hidden>🏢</span>
+        <span className="max-w-[180px] truncate">{label}</span>
+        <span className="text-xs opacity-70" aria-hidden>
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-2 min-w-[220px] space-y-2 rounded-xl bg-white/90 p-2 text-sm shadow-lg backdrop-blur-sm dark:bg-slate-900/90">
+          {fetching && (
+            <div className="px-2 py-1 text-contrast/70">Cargando organizaciones…</div>
+          )}
+          {error && !fetching && (
+            <div className="px-2 py-1 text-rose-600">{error}</div>
+          )}
+          {!fetching && !error && items.length === 0 && (
+            <div className="px-2 py-1 text-contrast/70">No se encontraron organizaciones</div>
+          )}
+          <ul className="max-h-64 overflow-auto" role="listbox">
+            {items.map((item) => {
+              const isActive = org?.id === item.id;
+              return (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    className={cn(
+                      "w-full rounded-lg px-2 py-2 text-left transition hover:bg-black/5 dark:hover:bg-white/10",
+                      isActive && "bg-black/5 font-semibold dark:bg-white/10",
+                    )}
+                    onClick={() => onPick(item)}
+                    aria-selected={isActive}
+                    role="option"
+                  >
+                    {item.name}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useActiveOrg.ts
+++ b/hooks/useActiveOrg.ts
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getActiveOrg as getLegacyActiveOrg, setActiveOrg as setLegacyActiveOrg } from "@/lib/org-local";
+import { getCurrentOrgId, listMyOrgs, setCurrentOrgId, type MyOrg } from "@/lib/org";
+
+export type ActiveOrg = { id: string; name: string; slug?: string };
+
+type ApplyOptions = {
+  emit?: boolean;
+  persistServer?: boolean;
+};
+
+function normalizeOrg(item: MyOrg): ActiveOrg {
+  return {
+    id: item.id,
+    name: item.is_personal ? "Personal" : item.name,
+    slug: item.slug ?? undefined,
+  };
+}
+
+function readStoredActiveOrg(): ActiveOrg | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem("active_org");
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ActiveOrg> | null;
+      if (parsed && typeof parsed.id === "string" && typeof parsed.name === "string") {
+        return { id: parsed.id, name: parsed.name, slug: parsed.slug };
+      }
+    }
+  } catch {
+    // ignore malformed JSON
+  }
+
+  const legacy = getLegacyActiveOrg();
+  if (legacy.id) {
+    return {
+      id: legacy.id,
+      name: legacy.name ?? "Organización",
+    };
+  }
+
+  return null;
+}
+
+function persistActiveOrgLocal(next: ActiveOrg | null) {
+  setLegacyActiveOrg(next ? next.id : null, next?.name ?? null);
+
+  if (typeof window === "undefined") return;
+
+  try {
+    if (next) {
+      window.localStorage.setItem("active_org", JSON.stringify(next));
+    } else {
+      window.localStorage.removeItem("active_org");
+    }
+  } catch {
+    // ignore storage write errors
+  }
+}
+
+export function useActiveOrg() {
+  const [org, setOrg] = useState<ActiveOrg | null>(() => readStoredActiveOrg());
+  const [loading, setLoading] = useState<boolean>(() => !readStoredActiveOrg());
+  const orgRef = useRef<ActiveOrg | null>(org);
+
+  useEffect(() => {
+    orgRef.current = org;
+  }, [org]);
+
+  const applyActiveOrg = useCallback(
+    (next: ActiveOrg | null, options: ApplyOptions = {}) => {
+      setOrg(next);
+      setLoading(false);
+      persistActiveOrgLocal(next);
+
+      if (typeof window !== "undefined" && options.emit) {
+        window.dispatchEvent(new CustomEvent("org:changed", { detail: next ?? null }));
+      }
+
+      if (options.persistServer && next) {
+        void setCurrentOrgId(next.id).catch(() => {
+          // silently ignore persistence errors
+        });
+      }
+    },
+    [],
+  );
+
+  const setActive = useCallback(
+    (next: ActiveOrg) => {
+      applyActiveOrg(next, { emit: true, persistServer: true });
+    },
+    [applyActiveOrg],
+  );
+
+  useEffect(() => {
+    if (org) {
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const [currentIdResult, orgsResult] = await Promise.allSettled([
+          getCurrentOrgId(),
+          listMyOrgs(),
+        ]);
+
+        const currentId =
+          currentIdResult.status === "fulfilled" ? currentIdResult.value : null;
+        const orgs =
+          orgsResult.status === "fulfilled" && Array.isArray(orgsResult.value)
+            ? (orgsResult.value as MyOrg[])
+            : [];
+
+        let nextOrg: ActiveOrg | null = null;
+        let shouldPersistServer = false;
+
+        if (orgs.length > 0) {
+          const match = currentId ? orgs.find((item) => item.id === currentId) : undefined;
+          const chosen = match ?? orgs[0];
+          if (chosen) {
+            nextOrg = normalizeOrg(chosen);
+            shouldPersistServer = !currentId || !match;
+          }
+        } else if (currentId) {
+          nextOrg = { id: currentId, name: "Organización" };
+          shouldPersistServer = false;
+        }
+
+        if (nextOrg && mounted) {
+          applyActiveOrg(nextOrg, { emit: true, persistServer: shouldPersistServer });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [applyActiveOrg, org]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleOrgChanged = (event: Event) => {
+      const detail = (event as CustomEvent<ActiveOrg | null>).detail;
+      if (detail && typeof detail === "object" && typeof detail.id === "string") {
+        applyActiveOrg({
+          id: detail.id,
+          name: detail.name ?? "Organización",
+          slug: detail.slug,
+        }, { emit: false, persistServer: false });
+      } else {
+        applyActiveOrg(null, { emit: false, persistServer: false });
+      }
+    };
+
+    const handleLegacyChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ orgId?: string | null }>).detail;
+      const nextId = detail?.orgId ?? null;
+      if (!nextId) {
+        applyActiveOrg(null, { emit: false, persistServer: false });
+        return;
+      }
+
+      let name = "Organización";
+      const legacy = getLegacyActiveOrg();
+      if (legacy.id === nextId && legacy.name) {
+        name = legacy.name;
+      } else if (orgRef.current?.id === nextId) {
+        name = orgRef.current.name;
+      }
+
+      applyActiveOrg({ id: nextId, name }, { emit: false, persistServer: false });
+    };
+
+    window.addEventListener("org:changed", handleOrgChanged);
+    window.addEventListener("sanoa:org-changed", handleLegacyChange);
+
+    return () => {
+      window.removeEventListener("org:changed", handleOrgChanged);
+      window.removeEventListener("sanoa:org-changed", handleLegacyChange);
+    };
+  }, [applyActiveOrg]);
+
+  return { org, loading, setActive };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useActiveOrg` hook that reads the active organization from local storage, refreshes from Supabase-backed lists, and propagates change events
- introduce a compact `OrgSwitcher` dropdown that lists available organizations and updates the active selection across the app
- embed the new organization switcher in the navbar layout next to the brand for quick access

## Testing
- pnpm lint *(fails: existing warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd70bb45d0832ab52980c903b93ad2