### PR TITLE
feat: add glass template library and org inspector

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { useToastSafe } from "@/components/Toast";
 import { getSupabaseBrowser } from "@/lib/supabase-browser";
 import { cn } from "@/lib/utils";
+import ActiveOrgInspector from "@/components/organizations/ActiveOrgInspector";
 
 type NavItem = { href: string; label: string; emoji: string };
 
@@ -100,48 +101,50 @@ export default function Navbar() {
             })}
           </nav>
 
-          {/* Quick links */}
-          <div
-            className="ml-auto hidden flex-wrap items-center justify-end gap-2 sm:flex"
-            aria-label="Accesos rápidos"
-          >
-            {QUICK_LINKS.map((item) => {
-              const isActive =
-                pathname === item.href ||
-                (item.href !== "/" && pathname.startsWith(item.href + "/"));
+          <div className="ml-auto flex items-center gap-2">
+            <div
+              className="hidden flex-wrap items-center justify-end gap-2 sm:flex"
+              aria-label="Accesos rápidos"
+            >
+              {QUICK_LINKS.map((item) => {
+                const isActive =
+                  pathname === item.href ||
+                  (item.href !== "/" && pathname.startsWith(item.href + "/"));
 
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={cn(
-                    "glass-btn bubble text-base font-semibold text-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900",
-                    isActive
-                      ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
-                      : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
-                  )}
-                >
-                  <span className="emoji mr-1" aria-hidden>
-                    {item.emoji}
-                  </span>
-                  {item.label}
-                </Link>
-              );
-            })}
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "glass-btn bubble text-base font-semibold text-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-sky-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-100 dark:focus-visible:ring-offset-slate-900",
+                      isActive
+                        ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
+                        : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
+                    )}
+                  >
+                    <span className="emoji mr-1" aria-hidden>
+                      {item.emoji}
+                    </span>
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </div>
+
+            <ActiveOrgInspector />
+
+            <button
+              onClick={handleSignOut}
+              disabled={signingOut}
+              className="glass-btn neon inline-flex shrink-0 items-center gap-2 text-base text-rose-600 transition-colors hover:bg-white/75 disabled:cursor-not-allowed disabled:opacity-70 focus-visible:ring-2 focus-visible:ring-rose-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-rose-200 dark:hover:bg-slate-950/55 dark:focus-visible:ring-offset-slate-900"
+              aria-busy={signingOut}
+            >
+              <span className="emoji" aria-hidden>
+                🔓
+              </span>
+              {signingOut ? "Cerrando…" : "Cerrar sesión"}
+            </button>
           </div>
-
-          {/* Sign out */}
-          <button
-            onClick={handleSignOut}
-            disabled={signingOut}
-            className="glass-btn neon ml-3 inline-flex shrink-0 items-center gap-2 text-base text-rose-600 transition-colors hover:bg-white/75 disabled:cursor-not-allowed disabled:opacity-70 focus-visible:ring-2 focus-visible:ring-rose-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-rose-200 dark:hover:bg-slate-950/55 dark:focus-visible:ring-offset-slate-900"
-            aria-busy={signingOut}
-          >
-            <span className="emoji" aria-hidden>
-              🔓
-            </span>
-            {signingOut ? "Cerrando…" : "Cerrar sesión"}
-          </button>
         </div>
       </div>
     </header>

--- a/components/organizations/ActiveOrgInspector.tsx
+++ b/components/organizations/ActiveOrgInspector.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import GlassModal from "@/components/ui/GlassModal";
+import { listMyOrgs, getCurrentOrgId, setCurrentOrgId, type MyOrg } from "@/lib/org";
+import ColorEmoji from "@/components/ColorEmoji";
+import { showToast } from "@/components/Toaster";
+
+export default function ActiveOrgInspector() {
+  const [open, setOpen] = React.useState(false);
+  const [orgs, setOrgs] = React.useState<MyOrg[]>([]);
+  const [current, setCurrent] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [changing, setChanging] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [list, cur] = await Promise.all([listMyOrgs(), getCurrentOrgId()]);
+      setOrgs(list);
+      setCurrent(cur);
+      setLoading(false);
+      return list;
+    } catch (err: any) {
+      console.error(err);
+      setError(err?.message || "No pudimos cargar tus organizaciones");
+      setLoading(false);
+      return [] as MyOrg[];
+    }
+  }, []);
+
+  React.useEffect(() => {
+    load();
+    const onChanged = (e: Event) => {
+      const detail = (e as CustomEvent)?.detail;
+      if (detail?.orgId) setCurrent(detail.orgId);
+    };
+    window.addEventListener("sanoa:org-changed", onChanged);
+    return () => window.removeEventListener("sanoa:org-changed", onChanged);
+  }, [load]);
+
+  const activeOrg = React.useMemo(() => orgs.find((org) => org.id === current) ?? null, [orgs, current]);
+
+  const handleChange = async (nextId: string) => {
+    setChanging(true);
+    try {
+      await setCurrentOrgId(nextId);
+      setCurrent(nextId);
+      showToast("Organización actualizada", "success");
+      setOpen(false);
+    } catch (err: any) {
+      console.error(err);
+      showToast(err?.message || "No pudimos cambiar la organización", "error");
+    } finally {
+      setChanging(false);
+    }
+  };
+
+  return (
+    <>
+      <button className="glass-btn text-sm" onClick={() => setOpen(true)}>
+        <span className="emoji" aria-hidden>
+          🏢
+        </span>
+        {activeOrg ? activeOrg.name : "Organización"}
+      </button>
+
+      <GlassModal
+        open={open}
+        onClose={() => setOpen(false)}
+        size="md"
+        title="Organización activa"
+        footer={
+          loading ? <span className="text-sm text-slate-500">Cargando…</span> : null
+        }
+      >
+        <div className="space-y-4">
+          {error && <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700">{error}</div>}
+
+          {activeOrg ? (
+            <div className="rounded-2xl border border-white/20 bg-white/80 p-4 shadow-sm dark:bg-slate-950/40">
+              <div className="flex items-center gap-3">
+                <ColorEmoji token={activeOrg.is_personal ? "estrella" : "laboratorio"} size={32} />
+                <div>
+                  <div className="text-lg font-semibold text-slate-800 dark:text-slate-100">{activeOrg.name}</div>
+                  <div className="text-sm text-slate-500">
+                    Rol: {activeOrg.role}
+                    {activeOrg.is_personal ? " · Espacio personal" : ""}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-white/30 bg-white/60 p-4 text-sm text-slate-500 dark:bg-slate-950/30">
+              No hay organización seleccionada.
+            </div>
+          )}
+
+          <div>
+            <h4 className="text-sm font-semibold text-slate-600">Cambiar organización</h4>
+            <div className="mt-2 space-y-2">
+              {orgs.map((org) => {
+                const isActive = org.id === current;
+                return (
+                  <button
+                    key={org.id}
+                    className={`w-full rounded-xl border px-3 py-2 text-left text-sm transition ${
+                      isActive
+                        ? "border-sky-400/60 bg-sky-50 text-sky-900 dark:border-sky-500/40 dark:bg-sky-950/40 dark:text-sky-100"
+                        : "border-white/30 bg-white/80 hover:border-sky-200 hover:bg-white dark:border-slate-800/40 dark:bg-slate-950/40 dark:hover:border-sky-500/40"
+                    }`}
+                    onClick={() => handleChange(org.id)}
+                    disabled={changing || isActive}
+                  >
+                    <div className="font-medium">{org.name}</div>
+                    <div className="text-xs text-slate-500">
+                      {org.is_personal ? "Espacio personal" : `Rol: ${org.role}`}
+                    </div>
+                  </button>
+                );
+              })}
+              {!orgs.length && !loading && (
+                <div className="rounded-xl border border-dashed border-white/40 bg-white/60 p-3 text-sm text-slate-500 dark:bg-slate-950/40">
+                  No perteneces a ninguna organización todavía.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </GlassModal>
+    </>
+  );
+}

--- a/components/templates/TemplateLibraryModal.tsx
+++ b/components/templates/TemplateLibraryModal.tsx
@@ -1,0 +1,768 @@
+"use client";
+
+import * as React from "react";
+import GlassModal from "@/components/ui/GlassModal";
+import {
+  listPrescriptionTemplates,
+  upsertPrescriptionTemplate,
+  togglePrescriptionTemplate,
+  deletePrescriptionTemplate,
+  type PrescriptionTemplate,
+  type PrescriptionTemplateContent,
+} from "@/lib/prescriptions/templates";
+import {
+  listReferralTemplates,
+  upsertReferralTemplate,
+  toggleReferralTemplate,
+  deleteReferralTemplate,
+  type ReferralTemplate,
+  type ReferralTemplateContent,
+} from "@/lib/referrals/templates";
+import { getCatalogByType, type CatalogTemplate } from "@/lib/templates/catalog";
+import { showToast } from "@/components/Toaster";
+import { cn } from "@/lib/utils";
+
+export type TemplateKind = "prescription" | "referral";
+
+type CommonDraft = {
+  id?: string;
+  org_id: string;
+  name: string;
+  is_active: boolean;
+  metaSpecialty: string;
+  metaSummary: string;
+};
+
+type PrescriptionDraft = CommonDraft & {
+  type: "prescription";
+  notes: string;
+  items: PrescriptionTemplateContent["items"];
+};
+
+type ReferralDraft = CommonDraft & {
+  type: "referral";
+  to_specialty: string;
+  to_doctor_name: string;
+  reason: string;
+  summary: string;
+  plan: string;
+};
+
+type Draft = PrescriptionDraft | ReferralDraft;
+
+type TemplateLibraryModalProps = {
+  orgId: string;
+  kind: TemplateKind;
+  open: boolean;
+  onClose: () => void;
+  onUse?: (_tpl: { id: string; name: string }) => void;
+};
+
+type LoadState = "idle" | "loading" | "error";
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+const PRESCRIPTION_EMPTY_ITEM = {
+  drug: "",
+  dose: "",
+  route: "",
+  frequency: "",
+  duration: "",
+  instructions: "",
+};
+
+function templateToDraft(kind: TemplateKind, tpl: PrescriptionTemplate | ReferralTemplate, orgId: string): Draft {
+  if (kind === "prescription") {
+    const content = tpl.content ?? { items: [] };
+    return {
+      type: "prescription",
+      id: tpl.id,
+      org_id: orgId,
+      name: tpl.name,
+      is_active: tpl.is_active ?? true,
+      metaSpecialty: content.meta?.specialty ?? "",
+      metaSummary: content.meta?.summary ?? "",
+      notes: content.notes ?? "",
+      items: Array.isArray(content.items) ? content.items.map((it) => ({ ...PRESCRIPTION_EMPTY_ITEM, ...it })) : [],
+    };
+  }
+  const content = tpl.content ?? {};
+  return {
+    type: "referral",
+    id: tpl.id,
+    org_id: orgId,
+    name: tpl.name,
+    is_active: tpl.is_active ?? true,
+    metaSpecialty: content.meta?.specialty ?? "",
+    metaSummary: content.meta?.summary ?? "",
+    to_specialty: content.to_specialty ?? "",
+    to_doctor_name: content.to_doctor_name ?? "",
+    reason: content.reason ?? "",
+    summary: content.summary ?? "",
+    plan: content.plan ?? "",
+  };
+}
+
+function draftToPayload(draft: Draft) {
+  if (draft.type === "prescription") {
+    const content: PrescriptionTemplateContent = {
+      meta: {
+        specialty: draft.metaSpecialty || undefined,
+        summary: draft.metaSummary || undefined,
+      },
+      notes: draft.notes || undefined,
+      items: draft.items.map((it) => ({
+        drug: it.drug.trim(),
+        dose: it.dose.trim(),
+        route: it.route.trim(),
+        frequency: it.frequency.trim(),
+        duration: it.duration.trim(),
+        instructions: it.instructions?.trim() || undefined,
+      })),
+    };
+    return {
+      id: draft.id,
+      org_id: draft.org_id,
+      name: draft.name.trim(),
+      content,
+      is_active: draft.is_active,
+    };
+  }
+  const content: ReferralTemplateContent = {
+    meta: {
+      specialty: draft.metaSpecialty || undefined,
+      summary: draft.metaSummary || undefined,
+    },
+    to_specialty: draft.to_specialty || undefined,
+    to_doctor_name: draft.to_doctor_name || undefined,
+    reason: draft.reason || undefined,
+    summary: draft.summary || undefined,
+    plan: draft.plan || undefined,
+  };
+  return {
+    id: draft.id,
+    org_id: draft.org_id,
+    name: draft.name.trim(),
+    content,
+    is_active: draft.is_active,
+  };
+}
+
+function createEmptyDraft(kind: TemplateKind, orgId: string): Draft {
+  if (kind === "prescription") {
+    return {
+      type: "prescription",
+      org_id: orgId,
+      name: "Nueva plantilla",
+      is_active: true,
+      metaSpecialty: "",
+      metaSummary: "",
+      notes: "",
+      items: [{ ...PRESCRIPTION_EMPTY_ITEM }],
+    };
+  }
+  return {
+    type: "referral",
+    org_id: orgId,
+    name: "Nueva plantilla",
+    is_active: true,
+    metaSpecialty: "",
+    metaSummary: "",
+    to_specialty: "",
+    to_doctor_name: "",
+    reason: "",
+    summary: "",
+    plan: "",
+  };
+}
+
+export default function TemplateLibraryModal({ orgId, kind, open, onClose, onUse }: TemplateLibraryModalProps) {
+  const [loadState, setLoadState] = React.useState<LoadState>("idle");
+  const [templates, setTemplates] = React.useState<Array<(PrescriptionTemplate | ReferralTemplate) & { type: TemplateKind }>>([]);
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [draft, setDraft] = React.useState<Draft | null>(null);
+  const [dirty, setDirty] = React.useState(false);
+  const [saveState, setSaveState] = React.useState<SaveState>("idle");
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [search, setSearch] = React.useState("");
+  const [showCatalog, setShowCatalog] = React.useState(false);
+  const saveTimer = React.useRef<NodeJS.Timeout | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoadState("loading");
+    try {
+      if (kind === "prescription") {
+        const rows = await listPrescriptionTemplates(orgId);
+        setTemplates(rows.map((r) => ({ ...r, type: "prescription" as const })));
+      } else {
+        const rows = await listReferralTemplates(orgId);
+        setTemplates(rows.map((r) => ({ ...r, type: "referral" as const })));
+      }
+      setLoadState("idle");
+    } catch (err: any) {
+      console.error(err);
+      setLoadState("error");
+      showToast(err?.message || "No pudimos cargar las plantillas", "error");
+    }
+  }, [kind, orgId]);
+
+  React.useEffect(() => {
+    if (open) {
+      load();
+      setSelectedId(null);
+      setDraft(null);
+      setSearch("");
+      setShowCatalog(false);
+    }
+  }, [open, load]);
+
+  const currentList = React.useMemo(() => {
+    if (!search.trim()) return templates;
+    const q = search.toLowerCase();
+    return templates.filter((tpl) => {
+      const meta = tpl.content?.meta;
+      const specialty = meta?.specialty ?? "";
+      const metaSummary = meta?.summary ?? "";
+      return (
+        tpl.name.toLowerCase().includes(q) ||
+        specialty.toLowerCase().includes(q) ||
+        metaSummary.toLowerCase().includes(q)
+      );
+    });
+  }, [templates, search]);
+
+  const catalog = React.useMemo(() => getCatalogByType(kind), [kind]);
+
+  const scheduleSave = React.useCallback(
+    (next: Draft) => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(async () => {
+        setSaveState("saving");
+        setErrorMessage(null);
+        try {
+          const payload = draftToPayload(next);
+          let newId = payload.id;
+          if (next.type === "prescription") {
+            const res = await upsertPrescriptionTemplate(payload);
+            newId = res.id;
+          } else {
+            const res = await upsertReferralTemplate(payload);
+            newId = res.id;
+          }
+          setSaveState("saved");
+          setDirty(false);
+          setTemplates((prev) => {
+            const updated = prev.filter((tpl) => tpl.id !== payload.id);
+            const base = {
+              ...payload,
+              id: newId,
+              content: payload.content,
+              type: next.type,
+            } as (PrescriptionTemplate | ReferralTemplate) & { type: TemplateKind };
+            return [...updated, base].sort((a, b) => a.name.localeCompare(b.name));
+          });
+          setSelectedId(newId ?? null);
+          setDraft((d) => (d ? { ...next, id: newId ?? next.id } : d));
+        } catch (err: any) {
+          console.error(err);
+          setSaveState("error");
+          setErrorMessage(err?.message || "No pudimos guardar la plantilla");
+          showToast(err?.message || "No pudimos guardar la plantilla", "error");
+        }
+      }, 900);
+    },
+    [],
+  );
+
+  React.useEffect(() => {
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, []);
+
+  const onSelectTemplate = (tpl: (PrescriptionTemplate | ReferralTemplate) & { type: TemplateKind }) => {
+    setSelectedId(tpl.id);
+    setDraft(templateToDraft(tpl.type, tpl as any, orgId));
+    setDirty(false);
+    setSaveState("idle");
+    setErrorMessage(null);
+  };
+
+  const onCreateNew = () => {
+    const fresh = createEmptyDraft(kind, orgId);
+    setSelectedId(null);
+    setDraft(fresh);
+    setDirty(true);
+    setSaveState("idle");
+    setErrorMessage(null);
+    scheduleSave(fresh);
+  };
+
+  const onToggleActive = async (tpl: (PrescriptionTemplate | ReferralTemplate) & { type: TemplateKind }) => {
+    const next = !tpl.is_active;
+    try {
+      if (tpl.type === "prescription") {
+        await togglePrescriptionTemplate(tpl.id, next);
+      } else {
+        await toggleReferralTemplate(tpl.id, next);
+      }
+      setTemplates((prev) =>
+        prev.map((row) => (row.id === tpl.id ? { ...row, is_active: next } : row)),
+      );
+      if (draft && draft.id === tpl.id) {
+        setDraft({ ...draft, is_active: next });
+      }
+    } catch (err: any) {
+      showToast(err?.message || "No pudimos actualizar la plantilla", "error");
+    }
+  };
+
+  const onDelete = async (tpl: (PrescriptionTemplate | ReferralTemplate) & { type: TemplateKind }) => {
+    if (!confirm(`¿Eliminar la plantilla "${tpl.name}"?`)) return;
+    try {
+      if (tpl.type === "prescription") {
+        await deletePrescriptionTemplate(tpl.id);
+      } else {
+        await deleteReferralTemplate(tpl.id);
+      }
+      setTemplates((prev) => prev.filter((row) => row.id !== tpl.id));
+      if (draft?.id === tpl.id) {
+        setDraft(null);
+        setSelectedId(null);
+      }
+      showToast("Plantilla eliminada", "success");
+    } catch (err: any) {
+      showToast(err?.message || "No pudimos eliminar la plantilla", "error");
+    }
+  };
+
+  const handleCatalogImport = async (tpl: CatalogTemplate) => {
+    try {
+      setSaveState("saving");
+      if (tpl.type === "prescription") {
+        await upsertPrescriptionTemplate({
+          org_id: orgId,
+          name: tpl.name,
+          content: tpl.content,
+          is_active: true,
+        });
+      } else {
+        await upsertReferralTemplate({
+          org_id: orgId,
+          name: tpl.name,
+          content: tpl.content,
+          is_active: true,
+        });
+      }
+      await load();
+      setSaveState("saved");
+      showToast("Plantilla agregada desde catálogo", "success");
+    } catch (err: any) {
+      console.error(err);
+      setSaveState("error");
+      showToast(err?.message || "No pudimos importar la plantilla", "error");
+    }
+  };
+
+  const updateDraft = (updater: (_draft: Draft) => Draft) => {
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const next = updater(prev);
+      setDirty(true);
+      scheduleSave(next);
+      return next;
+    });
+  };
+
+  const renderEditor = () => {
+    if (!draft) {
+      return (
+        <div className="rounded-2xl border border-white/20 bg-white/70 p-6 text-sm text-slate-500 dark:bg-slate-950/40">
+          Selecciona una plantilla para editarla o crea una nueva.
+        </div>
+      );
+    }
+    if (draft.type === "prescription") {
+      return (
+        <PrescriptionEditorForm
+          draft={draft}
+          onChange={updateDraft}
+          onUse={onUse}
+        />
+      );
+    }
+    return <ReferralEditorForm draft={draft} onChange={updateDraft} onUse={onUse} />;
+  };
+
+  const statusLabel = React.useMemo(() => {
+    if (saveState === "saving") return "Guardando…";
+    if (saveState === "saved") return "Cambios guardados";
+    if (saveState === "error") return errorMessage ?? "Error al guardar";
+    if (dirty) return "Cambios pendientes";
+    return "";
+  }, [saveState, dirty, errorMessage]);
+
+  return (
+    <GlassModal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      title={kind === "prescription" ? "Plantillas de recetas" : "Plantillas de referencias"}
+      footer={
+        statusLabel ? (
+          <div
+            className={cn("text-sm", saveState === "error" ? "text-rose-500" : "text-slate-500")}
+            aria-live="polite"
+          >
+            {statusLabel}
+          </div>
+        ) : null
+      }
+    >
+      <div className="grid gap-5 md:grid-cols-[280px,1fr]">
+        <aside className="space-y-4">
+          <div className="space-y-2">
+            <input
+              className="w-full rounded-xl border border-white/30 bg-white/80 px-3 py-2 text-sm shadow-inner focus:border-sky-400"
+              placeholder="Buscar por nombre o especialidad"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <div className="flex flex-wrap gap-2">
+              <button className="glass-btn text-sm" onClick={onCreateNew}>
+                ➕ Nueva plantilla
+              </button>
+              <button className="glass-btn text-sm" onClick={() => setShowCatalog((v) => !v)}>
+                📚 {showCatalog ? "Ocultar catálogo" : "Ver catálogo"}
+              </button>
+            </div>
+          </div>
+
+          <div className="max-h-80 overflow-y-auto rounded-2xl border border-white/20 bg-white/70 p-1 dark:bg-slate-950/40">
+            <ul>
+              {currentList.map((tpl) => {
+                const meta = tpl.content?.meta;
+                const specialty = meta?.specialty ?? "";
+                const isActive = tpl.is_active ?? true;
+                const isSelected = tpl.id === selectedId;
+                return (
+                  <li key={tpl.id}>
+                    <button
+                      className={cn(
+                        "w-full rounded-xl px-3 py-2 text-left text-sm transition",
+                        isSelected
+                          ? "bg-sky-500/20 text-sky-900 dark:text-sky-100"
+                          : "hover:bg-white/80 dark:hover:bg-slate-900/60",
+                      )}
+                      onClick={() => onSelectTemplate(tpl)}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium">{tpl.name}</span>
+                        <span
+                          className={cn(
+                            "rounded-full px-2 py-0.5 text-[11px]",
+                            isActive ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
+                          )}
+                        >
+                          {isActive ? "Activa" : "Inactiva"}
+                        </span>
+                      </div>
+                      {specialty ? <div className="text-xs text-slate-500">{specialty}</div> : null}
+                    </button>
+                    {isSelected && (
+                      <div className="flex items-center gap-2 px-3 pb-2 text-xs text-slate-500">
+                        <button
+                          className="glass-btn text-xs"
+                          onClick={() => onToggleActive(tpl)}
+                        >
+                          {tpl.is_active ? "Desactivar" : "Activar"}
+                        </button>
+                        <button className="glass-btn text-xs" onClick={() => onDelete(tpl)}>
+                          Eliminar
+                        </button>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+              {!currentList.length && (
+                <li className="px-3 py-6 text-center text-sm text-slate-500">Sin plantillas</li>
+              )}
+            </ul>
+          </div>
+
+          {showCatalog && (
+            <div className="space-y-2 rounded-2xl border border-white/20 bg-white/70 p-3 text-xs text-slate-600 dark:bg-slate-950/40">
+              <div className="flex items-center justify-between">
+                <strong>Catálogo inicial</strong>
+                <span>{catalog.length}</span>
+              </div>
+              <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
+                {catalog.map((tpl) => (
+                  <article key={tpl.slug} className="rounded-xl border border-white/30 bg-white/80 p-2">
+                    <div className="text-sm font-semibold">{tpl.name}</div>
+                    <div className="text-[11px] text-slate-500">{tpl.specialty}</div>
+                    <div className="mt-1 text-xs text-slate-600">{tpl.summary}</div>
+                    <button
+                      className="mt-2 glass-btn text-xs"
+                      onClick={() => handleCatalogImport(tpl)}
+                    >
+                      Agregar a mis plantillas
+                    </button>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {loadState === "loading" && (
+            <div className="text-xs text-slate-500">Cargando plantillas…</div>
+          )}
+          {loadState === "error" && (
+            <div className="text-xs text-rose-500">Error al cargar plantillas</div>
+          )}
+        </aside>
+
+        <section className="space-y-4">{renderEditor()}</section>
+      </div>
+    </GlassModal>
+  );
+}
+
+type PrescriptionEditorFormProps = {
+  draft: PrescriptionDraft;
+  onChange: (_updater: (_draft: Draft) => Draft) => void;
+  onUse?: TemplateLibraryModalProps["onUse"];
+};
+
+function PrescriptionEditorForm({ draft, onChange, onUse }: PrescriptionEditorFormProps) {
+  const update = (mutator: (_draft: PrescriptionDraft) => PrescriptionDraft) => {
+    onChange((current) => {
+      if (current.type !== "prescription") return current;
+      return mutator(current);
+    });
+  };
+
+  const updateItem = (idx: number, key: keyof PrescriptionDraft["items"][number], value: string) => {
+    update((cur) => ({
+      ...cur,
+      items: cur.items.map((it, i) => (i === idx ? { ...it, [key]: value } : it)),
+    }));
+  };
+
+  const addItem = () => {
+    update((cur) => ({
+      ...cur,
+      items: [...cur.items, { ...PRESCRIPTION_EMPTY_ITEM }],
+    }));
+  };
+
+  const removeItem = (idx: number) => {
+    update((cur) => ({
+      ...cur,
+      items: cur.items.filter((_, i) => i !== idx),
+    }));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Nombre</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.name}
+            onChange={(e) => update((cur) => ({ ...cur, name: e.target.value }))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Especialidad</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.metaSpecialty}
+            onChange={(e) => update((cur) => ({ ...cur, metaSpecialty: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Descripción breve</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.metaSummary}
+            onChange={(e) => update((cur) => ({ ...cur, metaSummary: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Notas</span>
+          <textarea
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            rows={3}
+            value={draft.notes}
+            onChange={(e) => update((cur) => ({ ...cur, notes: e.target.value }))}
+          />
+        </label>
+      </div>
+
+      <div className="rounded-2xl border border-white/20 bg-white/70 p-3 shadow-inner dark:bg-slate-950/40">
+        <div className="mb-2 flex items-center justify-between">
+          <h4 className="font-semibold text-slate-700">Fármacos</h4>
+          <button className="glass-btn text-sm" onClick={addItem}>
+            Añadir fármaco
+          </button>
+        </div>
+        <div className="space-y-3">
+          {draft.items.map((item, idx) => (
+            <div key={idx} className="rounded-xl border border-white/40 bg-white/80 p-3">
+              <div className="grid gap-2 md:grid-cols-3">
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Fármaco"
+                  value={item.drug}
+                  onChange={(e) => updateItem(idx, "drug", e.target.value)}
+                />
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Dosis"
+                  value={item.dose}
+                  onChange={(e) => updateItem(idx, "dose", e.target.value)}
+                />
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Vía"
+                  value={item.route}
+                  onChange={(e) => updateItem(idx, "route", e.target.value)}
+                />
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Frecuencia"
+                  value={item.frequency}
+                  onChange={(e) => updateItem(idx, "frequency", e.target.value)}
+                />
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Duración"
+                  value={item.duration}
+                  onChange={(e) => updateItem(idx, "duration", e.target.value)}
+                />
+                <input
+                  className="rounded-lg border border-white/40 bg-white/90 px-2 py-1 text-sm"
+                  placeholder="Indicaciones"
+                  value={item.instructions ?? ""}
+                  onChange={(e) => updateItem(idx, "instructions", e.target.value)}
+                />
+              </div>
+              <div className="mt-2 flex justify-end">
+                <button className="glass-btn text-xs" onClick={() => removeItem(idx)}>
+                  Eliminar
+                </button>
+              </div>
+            </div>
+          ))}
+          {!draft.items.length && <div className="text-sm text-slate-500">Sin renglones.</div>}
+        </div>
+      </div>
+
+      {draft.id && onUse ? (
+        <button
+          className="glass-btn neon"
+          onClick={() => onUse({ id: draft.id!, name: draft.name })}
+        >
+          Usar esta plantilla
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+type ReferralEditorFormProps = {
+  draft: ReferralDraft;
+  onChange: (_updater: (_draft: Draft) => Draft) => void;
+  onUse?: TemplateLibraryModalProps["onUse"];
+};
+
+function ReferralEditorForm({ draft, onChange, onUse }: ReferralEditorFormProps) {
+  const update = (mutator: (_draft: ReferralDraft) => ReferralDraft) => {
+    onChange((current) => {
+      if (current.type !== "referral") return current;
+      return mutator(current);
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Nombre</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.name}
+            onChange={(e) => update((cur) => ({ ...cur, name: e.target.value }))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Especialidad</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.metaSpecialty}
+            onChange={(e) => update((cur) => ({ ...cur, metaSpecialty: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Descripción breve</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.metaSummary}
+            onChange={(e) => update((cur) => ({ ...cur, metaSummary: e.target.value }))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Dirigido a especialidad</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.to_specialty}
+            onChange={(e) => update((cur) => ({ ...cur, to_specialty: e.target.value }))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Nombre del profesional</span>
+          <input
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            value={draft.to_doctor_name}
+            onChange={(e) => update((cur) => ({ ...cur, to_doctor_name: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Motivo</span>
+          <textarea
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            rows={2}
+            value={draft.reason}
+            onChange={(e) => update((cur) => ({ ...cur, reason: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Resumen clínico</span>
+          <textarea
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            rows={3}
+            value={draft.summary}
+            onChange={(e) => update((cur) => ({ ...cur, summary: e.target.value }))}
+          />
+        </label>
+        <label className="md:col-span-2 flex flex-col gap-1 text-sm">
+          <span className="text-slate-600">Plan sugerido</span>
+          <textarea
+            className="rounded-xl border border-white/30 bg-white/80 px-3 py-2"
+            rows={3}
+            value={draft.plan}
+            onChange={(e) => update((cur) => ({ ...cur, plan: e.target.value }))}
+          />
+        </label>
+      </div>
+
+      {draft.id && onUse ? (
+        <button className="glass-btn neon" onClick={() => onUse({ id: draft.id!, name: draft.name })}>
+          Usar esta plantilla
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/ui/GlassModal.tsx
+++ b/components/ui/GlassModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { ReactNode, useEffect } from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  footer?: ReactNode;
+  size?: "sm" | "md" | "lg";
+  children: ReactNode;
+};
+
+const sizes = {
+  sm: "max-w-md",
+  md: "max-w-2xl",
+  lg: "max-w-4xl",
+};
+
+export default function GlassModal({ open, onClose, title, footer, size = "md", children }: Props) {
+  useEffect(() => {
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    if (open) document.addEventListener("keydown", onEsc);
+    return () => document.removeEventListener("keydown", onEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className={`relative w-full ${sizes[size]} glass-card bubble`}>
+        {title ? (
+          <div className="flex items-center justify-between mb-3">
+            <div className="text-xl font-semibold">{title}</div>
+            <button className="glass-btn" onClick={onClose}>
+              ✖
+            </button>
+          </div>
+        ) : null}
+        <div className="space-y-3">{children}</div>
+        {footer ? <div className="mt-4 pt-3 border-t border-white/10">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/lib/prescriptions/templates.ts
+++ b/lib/prescriptions/templates.ts
@@ -1,0 +1,70 @@
+import { getSupabaseBrowser } from "@/lib/supabase-browser";
+
+export type PrescriptionTemplateContent = {
+  meta?: {
+    specialty?: string | null;
+    summary?: string | null;
+  } | null;
+  notes?: string | null;
+  items: Array<{
+    drug: string;
+    dose: string;
+    route: string;
+    frequency: string;
+    duration: string;
+    instructions?: string | null;
+  }>;
+};
+
+export type PrescriptionTemplate = {
+  id: string;
+  org_id: string;
+  name: string;
+  content: PrescriptionTemplateContent;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export async function listPrescriptionTemplates(orgId: string) {
+  const supabase = getSupabaseBrowser();
+  const { data, error } = await supabase
+    .from("prescription_templates")
+    .select("id, org_id, name, content, is_active, created_at, updated_at")
+    .eq("org_id", orgId)
+    .order("name", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as PrescriptionTemplate[];
+}
+
+export async function upsertPrescriptionTemplate(payload: {
+  id?: string;
+  org_id: string;
+  name: string;
+  content: PrescriptionTemplateContent;
+  is_active?: boolean;
+}) {
+  const supabase = getSupabaseBrowser();
+  const { data, error } = await supabase
+    .from("prescription_templates")
+    .upsert(payload, { onConflict: "id" })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data as { id: string };
+}
+
+export async function togglePrescriptionTemplate(id: string, next: boolean) {
+  const supabase = getSupabaseBrowser();
+  const { error } = await supabase
+    .from("prescription_templates")
+    .update({ is_active: next })
+    .eq("id", id);
+  if (error) throw error;
+}
+
+export async function deletePrescriptionTemplate(id: string) {
+  const supabase = getSupabaseBrowser();
+  const { error } = await supabase.from("prescription_templates").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/lib/referrals/templates.ts
+++ b/lib/referrals/templates.ts
@@ -1,0 +1,66 @@
+import { getSupabaseBrowser } from "@/lib/supabase-browser";
+
+export type ReferralTemplateContent = {
+  meta?: {
+    specialty?: string | null;
+    summary?: string | null;
+  } | null;
+  to_specialty?: string | null;
+  to_doctor_name?: string | null;
+  reason?: string | null;
+  summary?: string | null;
+  plan?: string | null;
+};
+
+export type ReferralTemplate = {
+  id: string;
+  org_id: string;
+  name: string;
+  content: ReferralTemplateContent;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export async function listReferralTemplates(orgId: string) {
+  const supabase = getSupabaseBrowser();
+  const { data, error } = await supabase
+    .from("referral_templates")
+    .select("id, org_id, name, content, is_active, created_at, updated_at")
+    .eq("org_id", orgId)
+    .order("name", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as ReferralTemplate[];
+}
+
+export async function upsertReferralTemplate(payload: {
+  id?: string;
+  org_id: string;
+  name: string;
+  content: ReferralTemplateContent;
+  is_active?: boolean;
+}) {
+  const supabase = getSupabaseBrowser();
+  const { data, error } = await supabase
+    .from("referral_templates")
+    .upsert(payload, { onConflict: "id" })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return data as { id: string };
+}
+
+export async function toggleReferralTemplate(id: string, next: boolean) {
+  const supabase = getSupabaseBrowser();
+  const { error } = await supabase
+    .from("referral_templates")
+    .update({ is_active: next })
+    .eq("id", id);
+  if (error) throw error;
+}
+
+export async function deleteReferralTemplate(id: string) {
+  const supabase = getSupabaseBrowser();
+  const { error } = await supabase.from("referral_templates").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/lib/templates/catalog.ts
+++ b/lib/templates/catalog.ts
@@ -1,0 +1,620 @@
+import type { PrescriptionTemplateContent } from "@/lib/prescriptions/templates";
+import type { ReferralTemplateContent } from "@/lib/referrals/templates";
+
+type BaseTemplate = {
+  slug: string;
+  name: string;
+  specialty: string;
+  summary: string;
+};
+
+type PrescriptionCatalogItem = BaseTemplate & {
+  type: "prescription";
+  content: PrescriptionTemplateContent;
+};
+
+type ReferralCatalogItem = BaseTemplate & {
+  type: "referral";
+  content: ReferralTemplateContent;
+};
+
+export type CatalogTemplate = PrescriptionCatalogItem | ReferralCatalogItem;
+
+export const CATALOG_TEMPLATES: CatalogTemplate[] = [
+  {
+    type: "prescription",
+    slug: "cardiologia-hta-control",
+    name: "Control de hipertensión arterial",
+    specialty: "Cardiología",
+    summary: "Ajuste antihipertensivo en paciente estable",
+    content: {
+      meta: { specialty: "Cardiología", summary: "Plan de control para hipertensión esencial" },
+      notes: "Control tensional domiciliario y seguimiento en 4 semanas.",
+      items: [
+        {
+          drug: "Losartán",
+          dose: "50 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "30 días",
+          instructions: "Tomar siempre a la misma hora.",
+        },
+        {
+          drug: "Hidroclorotiazida",
+          dose: "25 mg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "30 días",
+          instructions: "Administrar por la mañana.",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "cardiologia-insuficiencia-cardiaca",
+    name: "Insuficiencia cardiaca estable",
+    specialty: "Cardiología",
+    summary: "Triple terapia guiada por guías",
+    content: {
+      meta: { specialty: "Cardiología", summary: "Bloqueo neurohormonal en IC clase II" },
+      notes: "Ajustar dosis según tolerancia y creatinina. Laboratorio en 15 días.",
+      items: [
+        {
+          drug: "Sacubitril/Valsartán",
+          dose: "49/51 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "30 días",
+        },
+        {
+          drug: "Carvedilol",
+          dose: "12.5 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "30 días",
+        },
+        {
+          drug: "Espironolactona",
+          dose: "25 mg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "30 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "medicina-interna-dm2-debut",
+    name: "Diabetes tipo 2 – inicio de manejo",
+    specialty: "Medicina Interna",
+    summary: "Metformina + educación inicial",
+    content: {
+      meta: { specialty: "Medicina Interna", summary: "Inicio metformina en paciente con HbA1c < 9%" },
+      notes: "Educación nutricional y plan de actividad física moderada. Control en 6 semanas.",
+      items: [
+        {
+          drug: "Metformina liberación prolongada",
+          dose: "500 mg",
+          route: "VO",
+          frequency: "Con cena",
+          duration: "14 días",
+          instructions: "Luego aumentar a 1000 mg con cena si se tolera.",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "medicina-interna-hospital-post-covid",
+    name: "Seguimiento post COVID moderado",
+    specialty: "Medicina Interna",
+    summary: "Rehabilitación respiratoria y soporte",
+    content: {
+      meta: { specialty: "Medicina Interna", summary: "Plan de soporte post egreso" },
+      notes: "Reforzar ejercicios de expansión torácica y controlar saturación domiciliaria.",
+      items: [
+        {
+          drug: "Budesonida/Formoterol inhalador",
+          dose: "160/4.5 mcg",
+          route: "Inhalado",
+          frequency: "2 inhalaciones cada 12 h",
+          duration: "30 días",
+        },
+        {
+          drug: "Vitamina D3",
+          dose: "4000 UI",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "30 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "neumologia-eacp-exacerbacion",
+    name: "EPOC estable tras exacerbación",
+    specialty: "Neumología",
+    summary: "Triple terapia inhalada",
+    content: {
+      meta: { specialty: "Neumología", summary: "Control de síntomas post exacerbación" },
+      notes: "Control en 4 semanas con espirometría si es posible.",
+      items: [
+        {
+          drug: "Fluticasona/Umeclidinio/Vilanterol",
+          dose: "100/62.5/25 mcg",
+          route: "Inhalado",
+          frequency: "1 inhalación cada 24 h",
+          duration: "60 días",
+        },
+        {
+          drug: "N-acetilcisteína",
+          dose: "600 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "30 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "pediatria-infeccion-respiratoria",
+    name: "Infección respiratoria alta – pediatría",
+    specialty: "Pediatría",
+    summary: "Manejo sintomático y educación",
+    content: {
+      meta: { specialty: "Pediatría", summary: "Cuadro viral autolimitado" },
+      notes: "Control si fiebre > 72 h o signos de dificultad respiratoria.",
+      items: [
+        {
+          drug: "Paracetamol suspensión",
+          dose: "15 mg/kg",
+          route: "VO",
+          frequency: "Cada 6 h PRN",
+          duration: "5 días",
+          instructions: "No exceder 4 dosis en 24 h.",
+        },
+        {
+          drug: "Solución salina nasal",
+          dose: "2-3 gotas",
+          route: "Nasal",
+          frequency: "Cada 4 h PRN",
+          duration: "5 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "pediatria-crup-leve",
+    name: "Crup leve ambulatorio",
+    specialty: "Pediatría",
+    summary: "Dexametasona + humidificación",
+    content: {
+      meta: { specialty: "Pediatría", summary: "Paciente con escala Westley < 3" },
+      notes: "Indicar signos de alarma y control telefónico en 24 h.",
+      items: [
+        {
+          drug: "Dexametasona oral",
+          dose: "0.6 mg/kg (máx 10 mg)",
+          route: "VO",
+          frequency: "Dosis única",
+          duration: "1 día",
+        },
+        {
+          drug: "Budesonida nebulizada",
+          dose: "2 mg",
+          route: "Nebulización",
+          frequency: "Cada 12 h",
+          duration: "48 h",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "gineco-anticoncepcion-postparto",
+    name: "Anticoncepción postparto",
+    specialty: "Ginecología",
+    summary: "Método progestágeno exclusivo",
+    content: {
+      meta: { specialty: "Ginecología", summary: "Paciente lactante a las 6 semanas" },
+      notes: "Consejería en lactancia y signos de trombosis.",
+      items: [
+        {
+          drug: "Desogestrel",
+          dose: "75 mcg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "3 meses",
+          instructions: "Tomar a la misma hora todos los días.",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "gineco-sop-metabolico",
+    name: "Síndrome de ovario poliquístico",
+    specialty: "Endocrinología",
+    summary: "Metformina + cambios de estilo de vida",
+    content: {
+      meta: { specialty: "Endocrinología", summary: "Manejo metabólico inicial" },
+      notes: "Plan de reducción de peso gradual y control en 3 meses.",
+      items: [
+        {
+          drug: "Metformina",
+          dose: "850 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "90 días",
+        },
+        {
+          drug: "Ácido fólico",
+          dose: "5 mg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "90 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "dermatologia-acne-moderado",
+    name: "Acné inflamatorio moderado",
+    specialty: "Dermatología",
+    summary: "Retinoide tópico + antibiótico",
+    content: {
+      meta: { specialty: "Dermatología", summary: "Manejo combinado por 12 semanas" },
+      notes: "Educar sobre fotoprotección y posibles irritaciones iniciales.",
+      items: [
+        {
+          drug: "Adapaleno gel",
+          dose: "Aplicar capa fina",
+          route: "Tópico",
+          frequency: "Noche",
+          duration: "12 semanas",
+        },
+        {
+          drug: "Peróxido de benzoilo",
+          dose: "2.5%",
+          route: "Tópico",
+          frequency: "Mañana",
+          duration: "12 semanas",
+        },
+        {
+          drug: "Doxiciclina",
+          dose: "100 mg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "8 semanas",
+          instructions: "Tomar con abundante agua y evitar exposición solar directa.",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "reumatologia-artritis-flare",
+    name: "Artritis reumatoide – brote",
+    specialty: "Reumatología",
+    summary: "Corticoide puente + DMARD",
+    content: {
+      meta: { specialty: "Reumatología", summary: "Control de brote moderado" },
+      notes: "Solicitar VSG, PCR y perfil hepático en 4 semanas.",
+      items: [
+        {
+          drug: "Prednisona",
+          dose: "10 mg",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "14 días",
+          instructions: "Reducir 2.5 mg cada 5 días según respuesta.",
+        },
+        {
+          drug: "Metotrexato",
+          dose: "15 mg",
+          route: "VO",
+          frequency: "1 vez por semana",
+          duration: "12 semanas",
+          instructions: "Administrar con 5 mg de ácido fólico al día siguiente.",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "geriatria-fragilidad",
+    name: "Síndrome de fragilidad",
+    specialty: "Geriatría",
+    summary: "Suplementos y prevención de caídas",
+    content: {
+      meta: { specialty: "Geriatría", summary: "Plan integral para fragilidad leve" },
+      notes: "Recomendar programa de ejercicio supervisado y revisión de domicilio.",
+      items: [
+        {
+          drug: "Vitamina D3",
+          dose: "2000 UI",
+          route: "VO",
+          frequency: "Cada 24 h",
+          duration: "90 días",
+        },
+        {
+          drug: "Calcio elemental",
+          dose: "600 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "90 días",
+        },
+        {
+          drug: "Proteína en polvo",
+          dose: "20 g",
+          route: "VO",
+          frequency: "Post ejercicio",
+          duration: "90 días",
+        },
+      ],
+    },
+  },
+  {
+    type: "prescription",
+    slug: "medicina-familiar-embarazo-sintomatico",
+    name: "Síntomas digestivos en embarazo",
+    specialty: "Medicina Familiar",
+    summary: "Antiácidos y medidas higiénicas",
+    content: {
+      meta: { specialty: "Medicina Familiar", summary: "Ardor leve en segundo trimestre" },
+      notes: "Reforzar medidas dietéticas y signos de alarma obstétrica.",
+      items: [
+        {
+          drug: "Carbonato de calcio + magnesio",
+          dose: "1 tableta",
+          route: "VO",
+          frequency: "Cada 8 h PRN",
+          duration: "14 días",
+        },
+        {
+          drug: "Doxilamina/Piridoxina",
+          dose: "10/10 mg",
+          route: "VO",
+          frequency: "Cada 12 h",
+          duration: "14 días",
+        },
+      ],
+    },
+  },
+  // Referral templates
+  {
+    type: "referral",
+    slug: "cardiologia-evaluacion-preoperatoria",
+    name: "Evaluación preoperatoria cardiológica",
+    specialty: "Cardiología",
+    summary: "Valoración prequirúrgica paciente con factores de riesgo",
+    content: {
+      meta: { specialty: "Cardiología", summary: "Evaluación de riesgo cardiovascular" },
+      to_specialty: "Cardiología",
+      to_doctor_name: "Equipo de evaluación preoperatoria",
+      reason: "Paciente con antecedente de hipertensión y diabetes que requiere valoración de riesgo previo a cirugía abdominal.",
+      summary:
+        "Control adecuado de cifras tensionales. No presenta angina ni disnea de esfuerzo. Electrocardiograma basal con cambios inespecíficos de repolarización.",
+      plan:
+        "Solicito valoración integral para definir necesidad de pruebas complementarias y optimizar manejo perioperatorio.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "neumologia-polisonografia",
+    name: "Referencia a neumología – sospecha de SAHOS",
+    specialty: "Neumología",
+    summary: "Paciente con ronquido y somnolencia diurna",
+    content: {
+      meta: { specialty: "Neumología", summary: "Tamizaje positivo de apnea obstructiva" },
+      to_specialty: "Neumología del sueño",
+      to_doctor_name: "Clínica de trastornos del sueño",
+      reason: "Ronquido intenso, pausas respiratorias observadas por la pareja y somnolencia diurna (Epworth 14).",
+      summary:
+        "IMC 31 kg/m², circunferencia de cuello 42 cm. HTA controlada. No antecedentes de insuficiencia cardiaca.",
+      plan: "Solicito estudio de sueño y recomendaciones terapéuticas.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "endocrinologia-tiroides-nodulo",
+    name: "Evaluación endocrinología – nódulo tiroideo",
+    specialty: "Endocrinología",
+    summary: "Paciente con nódulo TI-RADS 4",
+    content: {
+      meta: { specialty: "Endocrinología", summary: "Estudio citológico de tiroides" },
+      to_specialty: "Endocrinología",
+      to_doctor_name: "Consulta de tiroides",
+      reason: "Ultrasonido detecta nódulo hipoecoico de 1.8 cm con bordes irregulares.",
+      summary:
+        "TSH dentro de rango. Sin antecedente familiar de cáncer tiroideo. No disfonía ni disfagia.",
+      plan: "Solicito valoración para biopsia por aspiración y plan de seguimiento.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "neurologia-epilepsia-control",
+    name: "Control de epilepsia",
+    specialty: "Neurología",
+    summary: "Paciente con crisis focales persistentes",
+    content: {
+      meta: { specialty: "Neurología", summary: "Ajuste de esquema antiepiléptico" },
+      to_specialty: "Neurología",
+      to_doctor_name: "Clínica de epilepsia",
+      reason: "Dos crisis focales en el último mes pese a adherencia a tratamiento.",
+      summary:
+        "Actualmente en levetiracetam 1000 mg cada 12 h. Resonancia 2023 sin cambios. EEG con descargas temporales derechas.",
+      plan: "Solicito ajuste terapéutico y evaluación de necesidad de estudios adicionales.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "traumatologia-rodilla-atleta",
+    name: "Lesión meniscal en deportista",
+    specialty: "Traumatología",
+    summary: "Dolor de rodilla y bloqueo mecánico",
+    content: {
+      meta: { specialty: "Traumatología", summary: "Evaluación artroscópica" },
+      to_specialty: "Traumatología deportiva",
+      to_doctor_name: "Dr. Martínez",
+      reason: "Paciente con dolor medial y bloqueo tras actividad de alto impacto.",
+      summary:
+        "RM reporta desgarro menisco medial grado III. No inestabilidad ligamentaria. Fisioterapia 6 semanas sin mejoría.",
+      plan: "Solicito valoración quirúrgica y recomendaciones de rehabilitación.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "psiquiatria-depresion-resistente",
+    name: "Depresión con respuesta parcial",
+    specialty: "Psiquiatría",
+    summary: "Seguimiento especializado por síntomas residuales",
+    content: {
+      meta: { specialty: "Psiquiatría", summary: "Optimización farmacológica" },
+      to_specialty: "Psiquiatría",
+      to_doctor_name: "Programa de trastornos del ánimo",
+      reason: "Persisten síntomas depresivos pese a sertralina 100 mg/día y psicoterapia.",
+      summary:
+        "PHQ-9 actual 15. Niega ideación suicida. Buen soporte familiar. No consumo de sustancias.",
+      plan: "Solicito evaluación para potencial augmentación y seguimiento conjunto.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "rehabilitacion-ictus-cronico",
+    name: "Rehabilitación post ictus",
+    specialty: "Medicina Física y Rehabilitación",
+    summary: "Déficit motor residual a los 3 meses",
+    content: {
+      meta: { specialty: "Rehabilitación", summary: "Plan intensivo de fisioterapia" },
+      to_specialty: "Rehabilitación neurológica",
+      to_doctor_name: "Equipo interdisciplinario",
+      reason: "Hemiparesia derecha y espasticidad braquial tras ACV isquémico.",
+      summary:
+        "Escala de Rankin modificada 3. Independiente para actividades básicas con ayuda parcial.",
+      plan: "Solicito programa integral de fisioterapia, terapia ocupacional y fonoaudiología.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "gineco-oncologia-lesion-cervical",
+    name: "Lesión cervical HSIL",
+    specialty: "Ginecología Oncológica",
+    summary: "Paciente con colposcopia sugestiva",
+    content: {
+      meta: { specialty: "Ginecología Oncológica", summary: "Evaluación para conización" },
+      to_specialty: "Ginecología oncológica",
+      to_doctor_name: "Unidad de patología cervical",
+      reason: "Citología con HSIL y biopsia dirigida que confirma NIC 3.",
+      summary:
+        "Paciente de 34 años, G1P1, sin deseo reproductivo inmediato. VIH negativo.",
+      plan: "Solicito valoración para tratamiento quirúrgico y seguimiento oncológico.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "nefrologia-proteinuria",
+    name: "Proteinuria persistente",
+    specialty: "Nefrología",
+    summary: "Diabético con deterioro renal progresivo",
+    content: {
+      meta: { specialty: "Nefrología", summary: "Evaluación nefroprotección" },
+      to_specialty: "Nefrología",
+      to_doctor_name: "Clínica de enfermedad renal crónica",
+      reason: "Proteinuria 1.2 g/24h pese a inhibidor SGLT2 y ARA II.",
+      summary:
+        "TFG 48 ml/min/1.73m². HbA1c 7.2%. Hipertensión controlada con tres fármacos.",
+      plan: "Solicito valoración para optimización terapéutica y estudio etiológico.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "oftalmologia-diabetes-tamiz",
+    name: "Tamizaje de retinopatía diabética",
+    specialty: "Oftalmología",
+    summary: "Paciente con 10 años de evolución de DM2",
+    content: {
+      meta: { specialty: "Oftalmología", summary: "Prevención de complicaciones visuales" },
+      to_specialty: "Oftalmología",
+      to_doctor_name: "Programa de retina",
+      reason: "Necesita control anual de fondo de ojo.",
+      summary:
+        "Glucemias en ayunas 110-130 mg/dl. HTA controlada. Sin síntomas visuales actuales.",
+      plan: "Solicito evaluación oftalmológica y registro fotográfico de retina.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "hematologia-anemia-ferropenica",
+    name: "Anemia ferropénica refractaria",
+    specialty: "Hematología",
+    summary: "Paciente con intolerancia a hierro oral",
+    content: {
+      meta: { specialty: "Hematología", summary: "Considerar hierro intravenoso" },
+      to_specialty: "Hematología",
+      to_doctor_name: "Clínica de anemia",
+      reason: "Persistencia de Hb 9 g/dl y ferritina 8 ng/ml pese a 3 meses de hierro oral.",
+      summary:
+        "Endoscopia alta sin hallazgos. Colonoscopia pendiente. No signos de hemorragia activa.",
+      plan: "Solicito valoración para infusión de hierro y estudio adicional.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "urologia-hiperplasia-prostatica",
+    name: "Hiperplasia prostática sintomática",
+    specialty: "Urología",
+    summary: "Paciente con IPSS severo pese a tratamiento médico",
+    content: {
+      meta: { specialty: "Urología", summary: "Evaluación intervencionista" },
+      to_specialty: "Urología",
+      to_doctor_name: "Dr. López",
+      reason: "Síntomas urinarios moderados-severos con tamsulosina y dutasteride.",
+      summary:
+        "Próstata 65 g en ultrasonido, PSA 3.2 ng/ml. Residuo posmiccional 120 ml.",
+      plan: "Solicito valoración para terapia quirúrgica mínimamente invasiva.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "alergologia-anafilaxia-evaluacion",
+    name: "Estudio de alergia alimentaria",
+    specialty: "Alergología",
+    summary: "Historia de reacción anafiláctica a mariscos",
+    content: {
+      meta: { specialty: "Alergología", summary: "Confirmar alérgenos específicos" },
+      to_specialty: "Alergología",
+      to_doctor_name: "Clínica de alergias",
+      reason: "Reacción anafiláctica hace 6 semanas posterior a ingesta de camarones.",
+      summary:
+        "Se administró adrenalina IM. Actualmente en evitación estricta. Porta autoinyector.",
+      plan: "Solicito pruebas cutáneas/específicas y plan de acción personalizado.",
+    },
+  },
+  {
+    type: "referral",
+    slug: "odontologia-implantes-diabetes",
+    name: "Evaluación odontología – implantes",
+    specialty: "Odontología",
+    summary: "Paciente diabético con pérdida dentaria múltiple",
+    content: {
+      meta: { specialty: "Odontología", summary: "Plan integral de rehabilitación" },
+      to_specialty: "Odontología rehabilitadora",
+      to_doctor_name: "Dr. Herrera",
+      reason: "Rehabilitación con implantes en maxilar superior.",
+      summary:
+        "Diabetes controlada (HbA1c 6.8%). Higiene oral adecuada. Radiografía panorámica adjunta.",
+      plan: "Solicito planificación protésica y tiempos quirúrgicos.",
+    },
+  },
+];
+
+export function getCatalogByType(type: CatalogTemplate["type"]) {
+  return CATALOG_TEMPLATES.filter((tpl) => tpl.type === type);
+}


### PR DESCRIPTION
## Summary
- add reusable glass modal wrapper and expose organization inspector in the navbar
- build a template library modal with autosave, specialty metadata, and catalog imports
- wire prescriptions and referrals UIs to the new library helpers and default template pack

## Testing
- pnpm lint *(fails: repository has existing lint warnings from unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7087c510832abe279736a3b19004