### PR TITLE
Add autosave prescription template editor

### DIFF
--- a/components/prescriptions/TemplateEditorModal.tsx
+++ b/components/prescriptions/TemplateEditorModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { useCallback } from "react";
+import GlassModal from "@/components/ui/GlassModal";
+import { useAutosave } from "@/hooks/useAutosave";
+
+export type RxTemplate = {
+  id?: string;
+  org_id?: string | null;
+  specialty: string;
+  title: string;
+  body: string;
+  notes?: string | null;
+  is_reference?: boolean | null;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initial: RxTemplate;
+  onSaved?: (_tpl: RxTemplate) => void;
+};
+
+type UpsertResponse = { ok?: boolean; data?: { id?: string } | null; id?: string; error?: { message?: string } };
+
+async function upsertTemplate(tpl: RxTemplate) {
+  const res = await fetch("/api/prescriptions/templates", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(tpl),
+  });
+  const json = (await res.json().catch(() => null)) as UpsertResponse | null;
+  if (!res.ok || json?.ok === false) {
+    const message = json?.error?.message || "No se pudo guardar";
+    throw new Error(message);
+  }
+  const id = json?.data?.id ?? json?.id ?? tpl.id;
+  const next: RxTemplate = { ...tpl, id };
+  return next;
+}
+
+export default function TemplateEditorModal({ open, onClose, initial, onSaved }: Props) {
+  const saveFn = useCallback(
+    async (draft: RxTemplate) => {
+      const saved = await upsertTemplate({
+        ...draft,
+        notes: draft.notes?.trim() ? draft.notes : null,
+      });
+      onSaved?.(saved);
+      return saved;
+    },
+    [onSaved],
+  );
+
+  const { data, setData, status, flush } = useAutosave(initial, saveFn);
+
+  return (
+    <GlassModal
+      open={open}
+      onClose={onClose}
+      title={
+        <div className="flex items-center gap-2">
+          <span className="emoji">🧪</span> Editar plantilla
+        </div>
+      }
+      footer={
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-contrast/70">
+            {status === "saving" && "Guardando…"}
+            {status === "saved" && "Guardado ✓"}
+            {status === "error" && "Error al guardar"}
+          </div>
+          <div className="flex gap-2">
+            <button className="glass-btn" onClick={() => void flush()}>
+              💾 Guardar ahora
+            </button>
+            <button className="glass-btn danger" onClick={onClose}>
+              Cerrar
+            </button>
+          </div>
+        </div>
+      }
+      size="lg"
+    >
+      <div className="grid gap-3">
+        <label className="text-sm text-contrast/80">Especialidad</label>
+        <input
+          className="input"
+          value={data.specialty}
+          onChange={(e) => setData({ ...data, specialty: e.target.value })}
+          placeholder="Ej. Medicina Familiar, Cardiología, Odontología…"
+        />
+        <label className="text-sm text-contrast/80">Título</label>
+        <input
+          className="input"
+          value={data.title}
+          onChange={(e) => setData({ ...data, title: e.target.value })}
+          placeholder="Ej. Amoxicilina 500 mg c/8h x7d"
+        />
+        <label className="text-sm text-contrast/80">Contenido (receta / referencia)</label>
+        <textarea
+          className="input min-h-44"
+          value={data.body}
+          onChange={(e) => setData({ ...data, body: e.target.value })}
+          placeholder="Formato libre: medicamento, dosis, vía, frecuencia, duración. O cuerpo de la carta de referencia."
+        />
+        <label className="text-sm text-contrast/80">Notas/Advertencias</label>
+        <textarea
+          className="input min-h-20"
+          value={data.notes ?? ""}
+          onChange={(e) => setData({ ...data, notes: e.target.value })}
+          placeholder="Alergias, interacciones, precauciones, seguimiento…"
+        />
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={Boolean(data.is_reference)}
+            onChange={(e) => setData({ ...data, is_reference: e.target.checked })}
+          />
+          <span className="text-sm">Es referencia (no receta)</span>
+        </label>
+      </div>
+    </GlassModal>
+  );
+}

--- a/components/prescriptions/TemplatePicker.tsx
+++ b/components/prescriptions/TemplatePicker.tsx
@@ -1,90 +1,227 @@
 "use client";
-import { useEffect, useState } from "react";
-
-type Template = { id: string; name: string; active?: boolean | null };
+import { useCallback, useEffect, useMemo, useState } from "react";
+import TemplateEditorModal, { RxTemplate } from "./TemplateEditorModal";
 
 type Props = {
-  orgId: string;
+  orgId?: string;
   mine?: boolean;
-  onChoose: (tpl: Template) => void;
+  onSelect?: (_tpl: RxTemplate) => void;
+  /** @deprecated usa onSelect */
+  onChoose?: (_tpl: RxTemplate) => void;
 };
 
-export default function TemplatePicker({ orgId, mine = false, onChoose }: Props) {
-  const [q, setQ] = useState("");
-  const [rows, setRows] = useState<Template[]>([]);
-  const [loading, setLoading] = useState(false);
+type ApiTemplate = Partial<RxTemplate> & {
+  id?: string;
+  org_id?: string | null;
+  name?: string;
+  content?: unknown;
+  body?: string;
+  title?: string;
+  specialty?: string | null;
+  notes?: string | null;
+  is_reference?: boolean | null;
+};
 
-  async function load() {
-    if (!orgId) {
-      setRows([]);
+function normalizeTemplate(raw: ApiTemplate): RxTemplate {
+  const content = (raw.content ?? {}) as Record<string, unknown>;
+  const specialty = (raw.specialty ?? content.specialty ?? "") as string;
+  const title = (raw.title ?? raw.name ?? (content.title as string) ?? "") as string;
+  const body = (raw.body ?? (content.body as string) ?? "") as string;
+  const notes = (raw.notes ?? (content.notes as string | null) ?? null) || null;
+  const isReference = (raw.is_reference ?? (content.is_reference as boolean | null) ?? false) || false;
+  return {
+    id: raw.id,
+    org_id: raw.org_id ?? (content.org_id as string | null) ?? null,
+    specialty,
+    title,
+    body,
+    notes,
+    is_reference: isReference,
+  };
+}
+
+export default function TemplatePicker({ orgId, mine = false, onSelect, onChoose }: Props) {
+  const [q, setQ] = useState("");
+  const [templates, setTemplates] = useState<RxTemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState<RxTemplate | null>(null);
+  const hasOrg = Boolean(orgId);
+
+  const fetchUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (orgId) params.set("org_id", orgId);
+    if (mine) params.set("mine", "1");
+    if (q.trim()) params.set("q", q.trim());
+    const query = params.toString();
+    return query ? `/api/prescriptions/templates?${query}` : "/api/prescriptions/templates";
+  }, [orgId, mine, q]);
+
+  const load = useCallback(async () => {
+    if (!hasOrg) {
+      setTemplates([]);
+      setError(null);
+      setLoading(false);
       return;
     }
     setLoading(true);
+    setError(null);
     try {
-      const params = new URLSearchParams({ org_id: orgId, mine: mine ? "1" : "0" });
-      if (q) params.set("q", q);
-
-      const r = await fetch(`/api/prescriptions/templates?${params.toString()}`, {
-        cache: "no-store",
-      });
-      const j = await r.json().catch(() => null);
-
-      if (j?.ok && Array.isArray(j.data)) {
-        setRows(j.data);
-      } else if (Array.isArray(j?.items)) {
-        setRows(j.items);
-      } else {
-        setRows([]);
+      const res = await fetch(fetchUrl, { cache: "no-store" });
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; data?: ApiTemplate[]; items?: ApiTemplate[]; error?: { message?: string } }
+        | ApiTemplate[]
+        | null;
+      if (!res.ok) {
+        const message =
+          (json && "error" in json && json.error?.message) || json?.toString() || "No se pudieron cargar las plantillas";
+        throw new Error(message);
       }
+      const list: ApiTemplate[] = Array.isArray(json)
+        ? json
+        : Array.isArray(json?.data)
+        ? (json?.data as ApiTemplate[])
+        : Array.isArray(json?.items)
+        ? (json?.items as ApiTemplate[])
+        : [];
+      setTemplates(list.map((item) => normalizeTemplate(item)));
     } catch (err) {
       console.error(err);
-      setRows([]);
+      setError(err instanceof Error ? err.message : "Error inesperado");
+      setTemplates([]);
     } finally {
       setLoading(false);
     }
-  }
+  }, [fetchUrl, hasOrg]);
 
   useEffect(() => {
-    load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId, q, mine]);
+    if (!hasOrg) return;
+    void load();
+  }, [hasOrg, load]);
+
+  const handleSelect = useCallback(
+    (tpl: RxTemplate) => {
+      onSelect?.(tpl);
+      onChoose?.(tpl);
+    },
+    [onChoose, onSelect],
+  );
+
+  const handleCreate = () => {
+    setCurrent({
+      org_id: orgId ?? null,
+      specialty: "",
+      title: "",
+      body: "",
+      notes: "",
+      is_reference: false,
+    });
+    setOpen(true);
+  };
+
+  const handleEdit = (tpl: RxTemplate) => {
+    setCurrent(tpl);
+    setOpen(true);
+  };
+
+  const handleSaved = useCallback(
+    (tpl: RxTemplate) => {
+      setTemplates((prev) => {
+        if (!tpl.id) {
+          void load();
+          return prev;
+        }
+        const idx = prev.findIndex((item) => item.id === tpl.id);
+        if (idx >= 0) {
+          const copy = [...prev];
+          copy[idx] = tpl;
+          return copy;
+        }
+        return [tpl, ...prev];
+      });
+      setCurrent(tpl);
+    },
+    [load],
+  );
 
   return (
-    <section className="border rounded-2xl p-4 space-y-3">
-      <div className="flex items-center gap-2">
-        <input
-          className="border rounded px-3 py-2 flex-1"
-          placeholder="Buscar plantilla..."
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-        />
-        <button className="border rounded px-3 py-2" onClick={load} disabled={loading}>
-          {loading ? "Cargando..." : "Buscar"}
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex w-full flex-col gap-2 sm:max-w-xl">
+          <label className="text-sm text-contrast/70" htmlFor="template-search">
+            Buscar plantilla
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="template-search"
+              className="input flex-1"
+              placeholder="Buscar plantilla..."
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && hasOrg) void load();
+              }}
+              disabled={!hasOrg}
+            />
+            <button className="glass-btn" onClick={load} disabled={loading || !hasOrg}>
+              {loading ? "Cargando..." : "Buscar"}
+            </button>
+          </div>
+        </div>
+        <button className="glass-btn primary self-end sm:self-auto" onClick={handleCreate} disabled={!hasOrg}>
+          ➕ Nueva
         </button>
       </div>
-      <div className="rounded border overflow-auto max-h-72">
-        <table className="w-full text-sm">
-          <tbody>
-            {rows.map((r) => (
-              <tr key={r.id} className="border-b">
-                <td className="px-3 py-2">{r.name}</td>
-                <td className="px-3 py-2 w-28 text-right">
-                  <button className="border rounded px-3 py-1" onClick={() => onChoose(r)}>
-                    Usar
-                  </button>
-                </td>
-              </tr>
-            ))}
-            {!rows.length && (
-              <tr>
-                <td className="px-3 py-6 text-center text-slate-500">
-                  {loading ? "Cargando..." : "Sin plantillas"}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+
+      {!hasOrg ? (
+        <div className="text-sm text-contrast/60">Selecciona una organización para ver o crear plantillas.</div>
+      ) : null}
+
+      {error ? (
+        <div className="text-sm text-red-500">{error}</div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {templates.map((tpl) => (
+          <div key={tpl.id ?? tpl.title} className="glass-card bubble text-contrast">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <div className="text-sm text-contrast/70">{tpl.specialty || "General"}</div>
+                <div className="font-semibold">{tpl.title || "Sin título"}</div>
+                <div className="badge mt-1">
+                  {tpl.is_reference ? "📝 Referencia" : "💊 Receta"}
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <button className="glass-btn" onClick={() => handleSelect(tpl)} disabled={!tpl.id}>
+                  📥 Usar
+                </button>
+                <button className="glass-btn" onClick={() => handleEdit(tpl)}>
+                  ✏️ Editar
+                </button>
+              </div>
+            </div>
+            <pre className="mt-3 whitespace-pre-wrap text-sm text-contrast/80">{tpl.body}</pre>
+            {tpl.notes ? <div className="mt-2 text-sm text-contrast/70">⚠️ {tpl.notes}</div> : null}
+          </div>
+        ))}
+        {!templates.length && !loading && !error && hasOrg ? (
+          <div className="rounded border border-dashed border-contrast/30 p-6 text-center text-sm text-contrast/70">
+            Sin plantillas
+          </div>
+        ) : null}
       </div>
-    </section>
+
+      {current ? (
+        <TemplateEditorModal
+          key={current.id ?? "new"}
+          open={open}
+          onClose={() => setOpen(false)}
+          initial={current}
+          onSaved={handleSaved}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/components/ui/GlassModal.tsx
+++ b/components/ui/GlassModal.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { ReactNode, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+type Size = "sm" | "md" | "lg" | "xl";
+
+type Props = {
+  open: boolean;
+  onClose?: () => void;
+  onOpenChange?: (_open: boolean) => void;
+  title?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  size?: Size;
+  className?: string;
+};
+
+const sizeMap: Record<Size, string> = {
+  sm: "max-w-md",
+  md: "max-w-lg",
+  lg: "max-w-3xl",
+  xl: "max-w-5xl",
+};
+
+export default function GlassModal({
+  open,
+  onClose,
+  onOpenChange,
+  title,
+  footer,
+  children,
+  size = "md",
+  className,
+}: Props) {
+  const close = () => {
+    onClose?.();
+    onOpenChange?.(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-md" onClick={close} aria-hidden />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={typeof title === "string" ? title : undefined}
+        className="relative z-[121] flex w-full justify-center"
+      >
+        <div className={cn("glass-card bubble w-full border border-white/20", sizeMap[size], className)}>
+          {title ? (
+            <div className="border-b border-white/20 px-5 py-4 text-lg font-semibold text-contrast flex items-center gap-2">
+              {title}
+            </div>
+          ) : null}
+          <div className="px-5 py-4 space-y-4 text-contrast">{children}</div>
+          {footer ? (
+            <div className="border-t border-white/20 bg-white/40 px-5 py-3 backdrop-blur text-contrast">
+              {footer}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useAutosave.ts
+++ b/hooks/useAutosave.ts
@@ -1,0 +1,43 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type SaveFn<T> = (_data: T) => Promise<T | void>;
+
+export function useAutosave<T>(initial: T, saveFn: SaveFn<T>, delay = 800) {
+  const [data, setData] = useState<T>(initial);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const timeoutRef = useRef<number | undefined>();
+
+  useEffect(() => {
+    setData(initial);
+    setStatus("idle");
+  }, [initial]);
+
+  const flush = useCallback(async () => {
+    window.clearTimeout(timeoutRef.current);
+    try {
+      setStatus("saving");
+      const result = await saveFn(data);
+      if (result) {
+        setData(result);
+      }
+      setStatus("saved");
+    } catch (err) {
+      console.error(err);
+      setStatus("error");
+    }
+  }, [data, saveFn]);
+
+  useEffect(() => {
+    window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = window.setTimeout(() => {
+      void flush();
+    }, delay);
+
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, [data, flush, delay]);
+
+  return { data, setData, status, flush };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useAutosave` hook to debounce saves and surface status updates
- implement a glass-styled modal editor for prescription templates with optimistic updates
- refresh the template picker UI to open the modal, support autosave editing, and handle optimistic list updates

## Testing
- pnpm lint *(fails: existing repository warnings)*
- pnpm typecheck *(fails: existing repository type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dd709adb4c832a8f4c954f0c5fd0e7