### PR TITLE
Fix RequireAuth lint error by removing leftover code fence

### DIFF
--- a/components/RequireAuth.tsx
+++ b/components/RequireAuth.tsx
@@ -1,5 +1,3 @@
-```tsx
-// components/RequireAuth.tsx
 "use client";
 
 import { useEffect, useState, type ReactNode } from "react";
@@ -54,4 +52,3 @@ export function RequireAuth({ children }: Props) {
 }
 
 export default RequireAuth;
-```


### PR DESCRIPTION
## Summary
- remove the stray Markdown code fence that made `RequireAuth` invalid TypeScript
- keep the existing logic intact so the component can export and lint correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd74d6fc90832aae2ce6f94a298f2d