### PR TITLE
feat: refresh tailwind design tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,45 +2,84 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ====== Variables de tema (claro/oscuro) ====== */
-:root{
-  --bg: 246 246 249;         /* #F6F6F9 */
-  --ink: 20 23 31;           /* texto base */
-  --muted: 90 95 110;
-  --surface: 255 255 255;    /* capas */
-  --contrast: 20 23 31;      /* para text-contrast */
+/* === Tokens de color (AA+) === */
+:root {
+  --bg: 0 0% 100%;
+  --fg: 222.2 47.4% 11.2%;
+  --card: 0 0% 100%;
+  --card-fg: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-fg: 215.4 16.3% 35%;
+  --border: 214.3 31.8% 91.4%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-fg: 210 40% 98%;
+  --secondary: 262 83% 58%;
+  --secondary-fg: 210 40% 98%;
+  --success: 142.1 70% 42%;
+  --success-fg: 210 40% 98%;
+  --danger: 0 72% 50%;
+  --danger-fg: 210 40% 98%;
+  --warning: 45 93% 47%;
+  --warning-fg: 20 14% 5%;
+  --contrast: 15 23 42;
   --glass-bg: 255 255 255;
   --glass-alpha: 0.14;
   --glass-border: 255 255 255;
-  --ring: 59 130 246;        /* azul ring */
+  --ring: 37 99 235;
 }
 
-.dark{
-  --bg: 10 12 16;            /* #0A0C10 */
-  --ink: 234 238 247;
-  --muted: 170 175 189;
-  --surface: 20 24 32;
-  --contrast: 234 238 247;
+[data-theme="dark"], .dark {
+  --bg: 222.2 84% 5%;
+  --fg: 210 40% 98%;
+  --card: 222.2 47% 12%;
+  --card-fg: 210 40% 98%;
+  --muted: 217 33% 17%;
+  --muted-fg: 215 20% 75%;
+  --border: 217 33% 22%;
+  --primary: 217.2 91% 60%;
+  --primary-fg: 222.2 47% 12%;
+  --secondary: 262 83% 62%;
+  --secondary-fg: 222.2 47% 12%;
+  --success: 142.1 70% 48%;
+  --success-fg: 210 40% 98%;
+  --danger: 0 72% 55%;
+  --danger-fg: 210 40% 98%;
+  --warning: 48 96% 55%;
+  --warning-fg: 222 47% 12%;
+  --contrast: 248 250 252;
   --glass-bg: 18 22 28;
-  --glass-alpha: 0.28;       /* más opaco en dark para contraste */
+  --glass-alpha: 0.28;
   --glass-border: 255 255 255;
-  --ring: 99 102 241;        /* indigo ring */
+  --ring: 60 131 246;
 }
 
-html, body {
-  @apply bg-[rgb(var(--bg))] text-[rgb(var(--ink))];
-  font-feature-settings: "ss01","ss02","cv01","cv02";
+html { font-size: 16px; }
+body {
+  background: hsl(var(--bg));
+  color: hsl(var(--fg));
+  font-family: var(--font-sans, ui-sans-serif, system-ui, -apple-system, "Inter", "Segoe UI", Roboto);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* ====== Tipografía global ====== */
-@layer base {
-  h1 { @apply text-2xl font-semibold leading-tight; }
-  h2 { @apply text-xl font-semibold leading-snug; }
-  h3 { @apply text-lg font-semibold leading-snug; }
-  p  { @apply leading-relaxed; }
-  small { @apply text-sm; }
+/* Accesibilidad y estados de foco */
+*:focus-visible {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
 }
 
+/* Tarjetas y helpers */
+.card { @apply rounded-xl bg-card text-card-foreground shadow-card border border-border; }
+.card-hover:hover { @apply shadow-card-hover; }
+
+/* Botón base por si se usa sin componente */
+.btn-base {
+  @apply inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition ease-soft;
+  @apply h-11 px-4; /* 44px de alto */
+}
+
+/* Emojis un poco más grandes y consistentes */
+.emoji { font-size: 1.25em; line-height: 1; vertical-align: -2px; }
 /* ====== Helpers ====== */
 .text-contrast { color: rgb(var(--contrast)); }
 .text-contrast\/80 { color: rgb(var(--contrast) / 0.8); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
+import { Inter, Plus_Jakarta_Sans } from "next/font/google";
 import Providers from "./providers";
 import AppShell from "@/components/AppShell";
 
-const bodyClass =
-  "font-body text-[var(--color-brand-text)] min-h-dvh antialiased bg-[length:100%_100%]";
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+const jakarta = Plus_Jakarta_Sans({ subsets: ["latin"], variable: "--font-display" });
 
 export const metadata: Metadata = {
   title: "Sanoa Lab",
@@ -22,7 +23,7 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es" suppressHydrationWarning>
-      <body className={bodyClass}>
+      <body className={`${inter.variable} ${jakarta.variable} antialiased`} data-theme="light">
         <Providers>
           <AppShell>{children}</AppShell>
         </Providers>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,38 +1,46 @@
 import type { Config } from "tailwindcss";
-import tailwindcssAnimate from "tailwindcss-animate";
 
-export default {
-  darkMode: "class",
+const config: Config = {
+  darkMode: ["class", '[data-theme="dark"]'],
   content: [
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
-    "./config/**/*.{ts,tsx}",
-    "./hooks/**/*.{ts,tsx}",
     "./lib/**/*.{ts,tsx}",
-    "./supabase/**/*.{ts,tsx}",
   ],
   theme: {
+    container: { center: true, padding: "1rem", screens: { "2xl": "1280px" } },
     extend: {
-      fontSize: {
-        base: "1.06rem",
-        lg: "1.18rem",
-        xl: "1.32rem",
-        "2xl": "1.6rem",
+      borderRadius: { lg: "12px", xl: "16px", "2xl": "20px" },
+      boxShadow: {
+        card: "0 1px 2px rgba(0,0,0,.04), 0 10px 24px rgba(0,0,0,.10)",
+        "card-hover": "0 2px 6px rgba(0,0,0,.06), 0 12px 28px rgba(0,0,0,.14)",
+        elevated: "0 12px 32px rgba(0,0,0,.18)",
       },
       colors: {
-        contrast: "rgb(var(--contrast) / <alpha-value>)",
+        background: "hsl(var(--bg))",
+        foreground: "hsl(var(--fg))",
+        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-fg))" },
+        card: { DEFAULT: "hsl(var(--card))", foreground: "hsl(var(--card-fg))" },
+        border: "hsl(var(--border))",
+        primary: { DEFAULT: "hsl(var(--primary))", foreground: "hsl(var(--primary-fg))" },
+        secondary: { DEFAULT: "hsl(var(--secondary))", foreground: "hsl(var(--secondary-fg))" },
+        success: { DEFAULT: "hsl(var(--success))", foreground: "hsl(var(--success-fg))" },
+        danger: { DEFAULT: "hsl(var(--danger))", foreground: "hsl(var(--danger-fg))" },
+        warning: { DEFAULT: "hsl(var(--warning))", foreground: "hsl(var(--warning-fg))" },
       },
-      boxShadow: {
-        glass: "0 8px 24px rgba(0,0,0,0.25)",
+      fontSize: {
+        xs: ["0.8125rem", "1.2"],
+        sm: ["0.875rem", "1.45"],
+        base: ["1rem", "1.6"],
+        lg: ["1.125rem", "1.55"],
+        xl: ["1.25rem", "1.4"],
+        "2xl": ["1.5rem", "1.3"],
+        "3xl": ["1.875rem", "1.2"],
       },
-      backdropBlur: {
-        xs: "2px",
-      },
-      borderRadius: {
-        "2xl": "1rem",
-        xl2: "1.25rem",
-      },
+      transitionTimingFunction: { soft: "cubic-bezier(.2,.8,.2,1)" },
     },
   },
-  plugins: [tailwindcssAnimate],
-} satisfies Config;
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/forms")],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- replace the Tailwind configuration with the new design tokens, shadows, and plugins
- update global CSS variables, base styles, and helper utilities to match the refreshed theme
- load Inter and Plus Jakarta Sans fonts in the root layout and set the initial data-theme attribute

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd968e3ba4832a86d26062549b52fe