### PR TITLE
Update button, card, and navbar components

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,144 +1,55 @@
-// components/Navbar.tsx
 "use client";
-
-import * as React from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import OrgSwitcher from "@/components/OrgSwitcher";
-import DensityToggle from "./DensityToggle";
-import ActiveOrgInspector from "@/components/organizations/ActiveOrgInspector";
-import { cn } from "@/lib/utils";
-import { getSupabaseBrowser } from "@/lib/supabase-browser";
-
-type NavItem = { href: string; label: string; emoji: string };
-
-const NAV: NavItem[] = [
-  { href: "/dashboard", label: "Dashboard", emoji: "🏠" },
-  { href: "/agenda", label: "Agenda", emoji: "📅" },
-  { href: "/pacientes", label: "Pacientes", emoji: "🧑‍⚕️" },
-  { href: "/consultorio", label: "Consultorio", emoji: "🏥" },
-  { href: "/especialidades", label: "Especialidades", emoji: "🧩" },
-  { href: "/banco", label: "Banco", emoji: "🏦" },
-];
-
-const QUICK_LINKS: NavItem[] = [
-  { href: "/recordatorios", label: "Recordatorios", emoji: "⏰" },
-  { href: "/perfil", label: "Perfil", emoji: "👤" },
-  { href: "/ajustes", label: "Ajustes", emoji: "⚙️" },
-];
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import OrgSwitcherBadge from "./OrgSwitcherBadge";
 
 export default function Navbar() {
-  const pathname = usePathname();
-  const router = useRouter();
-  const [signingOut, setSigningOut] = React.useState(false);
-
-  async function handleSignOut() {
-    try {
-      setSigningOut(true);
-      const supa = getSupabaseBrowser();
-      await supa.auth.signOut();
-      router.push("/login");
-      router.refresh();
-    } catch {
-      // opcional: podrías mostrar un toast si tienes un sistema de notificaciones
-    } finally {
-      setSigningOut(false);
-    }
-  }
+  const [open, setOpen] = useState(false);
 
   return (
-    <nav className="sticky top-0 z-40 glass-card bubble nav-lg !rounded-2xl mx-2 mt-2">
-      <div className="flex flex-wrap items-center gap-3 px-2 md:px-3">
-        {/* Brand + Org */}
-        <div className="flex items-center gap-3 min-w-0">
-          <Link
-            href="/dashboard"
-            className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight"
-            aria-label="Ir al dashboard"
-          >
-            <span className="emoji" aria-hidden>✨</span>
-            <span>Sanoa</span>
+    <header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-sm">
+      <nav className="container h-[64px] flex items-center gap-3">
+        <div className="flex items-center gap-3">
+          <OrgSwitcherBadge />
+          <Link href="/" className="font-bold text-lg" aria-label="Inicio Sanoa">
+            Sanoa
           </Link>
-
-          <OrgSwitcher />
         </div>
 
-        {/* Main nav */}
-        <nav
-          className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto whitespace-nowrap"
-          aria-label="Secciones principales"
+        <div className="ml-auto hidden md:flex items-center gap-6">
+          <Link href="/consultorio" className="text-sm hover:opacity-80">Consultorio</Link>
+          <Link href="/pacientes" className="text-sm hover:opacity-80">Pacientes</Link>
+          <Link href="/especialidades" className="text-sm hover:opacity-80">Especialidades</Link>
+          <Link href="/banco" className="text-sm hover:opacity-80">Banco</Link>
+          <Button asChild variant="primary" size="md" className="font-bold">
+            <Link href="/signup">Crear cuenta</Link>
+          </Button>
+        </div>
+
+        {/* Mobile */}
+        <button
+          className="md:hidden btn-base ghost"
+          aria-label="Menú"
+          onClick={() => setOpen((s) => !s)}
         >
-          {NAV.map((item) => {
-            const isActive =
-              pathname === item.href ||
-              (item.href !== "/" && pathname.startsWith(item.href + "/"));
+          ☰
+        </button>
+      </nav>
 
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "glass-btn bubble text-sm md:text-base font-semibold transition-colors",
-                  isActive
-                    ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
-                    : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
-                )}
-                title={item.label}
-              >
-                <span className="emoji mr-1" aria-hidden>{item.emoji}</span>
-                {item.label}
-              </Link>
-            );
-          })}
-        </nav>
-
-        {/* Quick links + tools */}
-        <div className="ml-auto flex items-center gap-2">
-          <div
-            className="hidden sm:flex flex-wrap items-center justify-end gap-2"
-            aria-label="Accesos rápidos"
-          >
-            {QUICK_LINKS.map((item) => {
-              const isActive =
-                pathname === item.href ||
-                (item.href !== "/" && pathname.startsWith(item.href + "/"));
-
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "glass-btn bubble text-sm md:text-base font-semibold transition-colors",
-                    isActive
-                      ? "neon bg-white/85 text-slate-900 dark:bg-slate-900/70 dark:text-white"
-                      : "bg-white/60 hover:bg-white/75 dark:bg-slate-950/40 dark:hover:bg-slate-950/55",
-                  )}
-                  title={item.label}
-                >
-                  <span className="emoji mr-1" aria-hidden>{item.emoji}</span>
-                  {item.label}
-                </Link>
-              );
-            })}
+      {open && (
+        <div className="md:hidden border-t border-border bg-background">
+          <div className="container py-3 flex flex-col gap-2">
+            <Link href="/consultorio" className="py-2">Consultorio</Link>
+            <Link href="/pacientes" className="py-2">Pacientes</Link>
+            <Link href="/especialidades" className="py-2">Especialidades</Link>
+            <Link href="/banco" className="py-2">Banco</Link>
+            <Button asChild variant="primary" className="mt-1">
+              <Link href="/signup">Crear cuenta</Link>
+            </Button>
           </div>
-
-          <ActiveOrgInspector />
-
-          <button
-            onClick={handleSignOut}
-            disabled={signingOut}
-            className="glass-btn neon inline-flex shrink-0 items-center gap-2 text-sm md:text-base text-rose-600 transition-colors hover:bg-white/75 disabled:cursor-not-allowed disabled:opacity-70 focus-visible:ring-2 focus-visible:ring-rose-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-rose-200 dark:hover:bg-slate-950/55 dark:focus-visible:ring-offset-slate-900"
-            aria-busy={signingOut}
-          >
-            <span className="emoji" aria-hidden>🔓</span>
-            {signingOut ? "Cerrando…" : "Cerrar sesión"}
-          </button>
-
-          <DensityToggle />
         </div>
-      </div>
-    </nav>
+      )}
+    </header>
   );
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,41 +1,51 @@
 import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition " +
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/50 " +
-    "disabled:pointer-events-none disabled:opacity-50 rounded-2xl",
+  "btn-base select-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:opacity-50 disabled:pointer-events-none",
   {
     variants: {
       variant: {
-        default: "bg-sky-600 text-white hover:bg-sky-700",
-        outline: "border border-slate-200 dark:border-slate-800",
-        ghost: "hover:bg-slate-100 dark:hover:bg-slate-900",
-        glass: "glass-btn",
+        primary: "bg-primary text-primary-foreground hover:opacity-90 active:opacity-80",
+        secondary: "bg-secondary text-secondary-foreground hover:opacity-90 active:opacity-80",
+        outline: "border border-border bg-transparent hover:bg-muted",
+        ghost: "bg-transparent hover:bg-muted",
+        danger: "bg-danger text-danger-foreground hover:opacity-90 active:opacity-80",
+        destructive: "bg-danger text-danger-foreground hover:opacity-90 active:opacity-80",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 px-3",
-        lg: "h-12 px-6 text-base",
-        icon: "h-10 w-10",
+        sm: "h-10 px-3 text-sm",
+        md: "h-11 px-4 text-base",
+        lg: "h-12 px-5 text-base",
+        icon: "h-11 w-11 p-0",
       },
     },
-    defaultVariants: {
-      variant: "glass",
-      size: "default",
-    },
+    defaultVariants: { variant: "primary", size: "md" },
   }
 );
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
-
-export function Button({ className, variant, size, ...props }: ButtonProps) {
-  return (
-    <button className={cn(buttonVariants({ variant, size, className }))} {...props} />
-  );
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
 }
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
 
 export { buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,41 +1,29 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("glass-card text-contrast", className)} {...props} />
-  ),
-);
-Card.displayName = "Card";
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("card", className)} {...props} />;
+}
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("mb-3", className)} {...props} />
-  ),
-);
-CardHeader.displayName = "CardHeader";
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-5 pb-3", className)} {...props} />;
+}
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn(className)} {...props} />,
-);
-CardContent.displayName = "CardContent";
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-xl font-bold", className)} {...props} />;
+}
 
-const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h2
-      ref={ref}
-      className={cn("text-xl font-semibold leading-none tracking-tight", className)}
-      {...props}
-    />
-  ),
-);
-CardTitle.displayName = "CardTitle";
+export function CardDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("mt-4", className)} {...props} />
-  ),
-);
-CardFooter.displayName = "CardFooter";
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-5 pt-0", className)} {...props} />;
+}
 
-export { Card, CardHeader, CardContent, CardTitle, CardFooter };
+export function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-5 pt-0 flex items-center gap-2", className)} {...props} />;
+}


### PR DESCRIPTION
## Summary
- replace the button variant system with the new shared styles and keep asChild support
- update the card primitives to match the new spacing and typography rules
- rebuild the navbar layout around the sticky 64px design with the org switcher badge and CTA

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd96ab4344832a8ac71417b89e0be2