### PR TITLE
Add prescriptions templates page and adjust consultorio copy

### DIFF
--- a/app/(app)/consultorio/page.tsx
+++ b/app/(app)/consultorio/page.tsx
@@ -34,7 +34,9 @@ export default function Consultorio() {
             />
           </div>
         </div>
-        <p className="mt-2 text-sm text-contrast">Solo aparecen pacientes de tu organización.</p>
+        <p className="text-sm text-muted-foreground">
+          Solo se muestran pacientes de tu organización.
+        </p>
         {!orgId && (
           <p className="text-xs text-contrast/70">
             Conéctate a una organización para ver resultados.

--- a/app/(app)/prescriptions/templates/page.tsx
+++ b/app/(app)/prescriptions/templates/page.tsx
@@ -1,22 +1,17 @@
 import TemplatePicker from "@/components/prescriptions/TemplatePicker";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
-export const dynamic = "force-dynamic";
-
-export default function TemplatesPage() {
+export default function RxTemplatesPage() {
   return (
-    <main className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">
-        <span className="emoji">📚</span> Plantillas
-      </h1>
-      <div className="glass-card bubble">
-        <TemplatePicker
-          onSelect={(tpl) => {
-            // Aquí puedes navegar al editor de receta, o inyectar en /prescriptions/create
-            // Ejemplo simple:
-            alert(`Usar plantilla: ${tpl.title}`);
-          }}
-        />
-      </div>
+    <main className="container py-6">
+      <Card className="card-hover">
+        <CardHeader>
+          <CardTitle className="font-bold">Plantillas de Recetas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TemplatePicker />
+        </CardContent>
+      </Card>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild the prescriptions templates page using the shared TemplatePicker inside a card layout
- update the consultorio search hint text to match the new copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd97c5440c832aaa3829fe9be05496