### PR TITLE
Add accessible focus outlines and loading skeletons to key lists

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,8 +84,9 @@ body {
 
 /* Accesibilidad (focus visible) */
 *:focus-visible {
-  outline: 2px solid hsl(var(--primary));
-  outline-offset: 2px;
+  outline: 3px solid rgb(var(--ring));
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgb(var(--ring) / 0.25);
 }
 
 /* ===== UI helpers ===== */

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -48,6 +48,7 @@ export default function ThemeToggle() {
         aria-pressed={theme === "light"}
         className={btn(theme === "light")}
         title="Modo claro"
+        aria-label="Activar modo claro"
       >
         ☀️ <span className="sr-only">Claro</span>
       </button>
@@ -57,6 +58,7 @@ export default function ThemeToggle() {
         aria-pressed={theme === "system"}
         className={btn(theme === "system")}
         title="Según el sistema"
+        aria-label="Usar tema del sistema"
       >
         🖥️ <span className="sr-only">Sistema</span>
       </button>
@@ -66,6 +68,7 @@ export default function ThemeToggle() {
         aria-pressed={theme === "dark"}
         className={btn(theme === "dark")}
         title="Modo oscuro"
+        aria-label="Activar modo oscuro"
       >
         🌙 <span className="sr-only">Oscuro</span>
       </button>

--- a/components/bank/TxTable.tsx
+++ b/components/bank/TxTable.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 import EmptyState from "@/components/ui/EmptyState";
+import Skeleton from "@/components/ui/Skeleton";
 
 type Tx = {
   id: string;
@@ -64,6 +65,7 @@ export default function TxTable({ orgId }: { orgId: string }) {
   const [rows, setRows] = useState<Tx[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const skeletonRows = Array.from({ length: 6 });
 
   const page = Math.max(1, Number(search.get("page") ?? "1"));
   const pageSize = Math.max(1, Math.min(200, Number(search.get("pageSize") ?? "50")));
@@ -129,7 +131,7 @@ export default function TxTable({ orgId }: { orgId: string }) {
       ) : (
         <>
           <div className="rounded border overflow-hidden">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm" aria-busy={loading}>
               <thead className="bg-gray-50">
                 <tr>
                   <th className="text-left px-3 py-2">Fecha</th>
@@ -140,13 +142,30 @@ export default function TxTable({ orgId }: { orgId: string }) {
                 </tr>
               </thead>
               <tbody>
-                {loading && (
-                  <tr>
-                    <td className="px-3 py-6 text-center" colSpan={5}>
-                      Cargando…
-                    </td>
-                  </tr>
-                )}
+                {loading &&
+                  skeletonRows.map((_, idx) => (
+                    <tr key={`tx-skeleton-${idx}`} className={idx === 0 ? undefined : "border-t"}>
+                      <td className="px-3 py-3">
+                        <Skeleton
+                          className="h-4 w-24"
+                          label="Cargando transacciones"
+                          ariaHidden={idx > 0}
+                        />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Skeleton className="h-4 w-40" ariaHidden />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Skeleton className="ml-auto h-4 w-20" ariaHidden />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Skeleton className="h-4 w-24" ariaHidden />
+                      </td>
+                      <td className="px-3 py-3">
+                        <Skeleton className="h-4 w-24" ariaHidden />
+                      </td>
+                    </tr>
+                  ))}
                 {!loading && rows.length === 0 && (
                   <tr>
                     <td className="px-3 py-6 text-center" colSpan={5}>

--- a/components/patients/Table.tsx
+++ b/components/patients/Table.tsx
@@ -4,6 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
+import EmptyState from "@/components/EmptyState";
+import Skeleton from "@/components/ui/Skeleton";
+
 type Row = {
   id: string;
   name: string | null;
@@ -29,6 +32,8 @@ export default function PatientsTable({ orgId }: { orgId: string }) {
     total: 0,
   });
   const [loading, setLoading] = useState(true);
+
+  const skeletonRows = Array.from({ length: 5 });
 
   const page = useMemo(() => Number(search.get("page") ?? 1), [search]);
   const pageSize = useMemo(() => Number(search.get("pageSize") ?? 50), [search]);
@@ -57,9 +62,11 @@ export default function PatientsTable({ orgId }: { orgId: string }) {
     };
   }, [orgId, search, page, pageSize]);
 
+  const showEmpty = !loading && rows.length === 0;
+
   return (
     <div className="rounded-2xl border overflow-hidden">
-      <table className="w-full text-sm">
+      <table className="w-full text-sm" aria-busy={loading}>
         <thead className="bg-gray-50">
           <tr>
             <th className="text-left px-3 py-2">Nombre</th>
@@ -71,26 +78,40 @@ export default function PatientsTable({ orgId }: { orgId: string }) {
           </tr>
         </thead>
         <tbody>
-          {loading && (
-            <tr>
-              <td colSpan={6} className="px-3 py-6 text-center">
-                Cargando…
-              </td>
-            </tr>
-          )}
-          {!loading && rows.length === 0 && (
-            <tr>
-              <td colSpan={6} className="px-3 py-6 text-center">
-                Sin resultados.
-              </td>
-            </tr>
-          )}
-          {rows.map((r) => (
-            <tr key={r.id} className="border-t">
-              <td className="px-3 py-2">
-                <Link href={`/pacientes/${r.id}`} className="underline underline-offset-2">
-                  {r.name ?? "—"}
-                </Link>
+          {loading &&
+            skeletonRows.map((_, idx) => (
+              <tr key={`patients-skeleton-${idx}`} className={idx === 0 ? undefined : "border-t"}>
+                <td className="px-3 py-3">
+                  <Skeleton
+                    className="h-4 w-40"
+                    label="Cargando pacientes"
+                    ariaHidden={idx > 0}
+                  />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-20" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-12" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-32" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-24" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-24" ariaHidden />
+                </td>
+              </tr>
+            ))}
+          {!loading &&
+            rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="px-3 py-2">
+                  <Link href={`/pacientes/${r.id}`} className="underline underline-offset-2">
+                    {r.name ?? "—"}
+                  </Link>
               </td>
               <td className="px-3 py-2">{r.gender ?? "—"}</td>
               <td className="px-3 py-2">{ageYears(r.dob)}</td>
@@ -102,7 +123,19 @@ export default function PatientsTable({ orgId }: { orgId: string }) {
                 {r.deleted_at ? new Date(r.deleted_at).toLocaleDateString() : "—"}
               </td>
             </tr>
-          ))}
+            ))}
+          {showEmpty && (
+            <tr>
+              <td colSpan={6} className="px-3 py-8">
+                <EmptyState
+                  emoji="🧑‍⚕️"
+                  title="Sin pacientes coincidentes"
+                  hint="Ajusta los filtros o registra un nuevo paciente para verlo aquí."
+                  className="mx-auto max-w-md border border-dashed border-border bg-transparent shadow-none"
+                />
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
 

--- a/components/reminders/QueueTable.tsx
+++ b/components/reminders/QueueTable.tsx
@@ -4,6 +4,8 @@
 import * as React from "react";
 import { getActiveOrg } from "@/lib/org-local";
 
+import Skeleton from "@/components/ui/Skeleton";
+
 type Item = {
   id: string;
   assignment_id: string | null;
@@ -23,6 +25,7 @@ export default function QueueTable() {
   const [items, setItems] = React.useState<Item[]>([]);
   const [status, setStatus] = React.useState<string>("");
   const [loading, setLoading] = React.useState(false);
+  const skeletonRows = React.useMemo(() => Array.from({ length: 5 }), []);
 
   async function load() {
     if (!org.id) {
@@ -81,7 +84,7 @@ export default function QueueTable() {
       </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table className="w-full text-sm" aria-busy={loading}>
           <thead>
             <tr className="border-t border-b bg-slate-50/60 dark:bg-slate-800/40">
               <th className="text-left p-2">Fecha</th>
@@ -94,6 +97,36 @@ export default function QueueTable() {
             </tr>
           </thead>
           <tbody>
+            {loading &&
+              skeletonRows.map((_, idx) => (
+                <tr key={`queue-skeleton-${idx}`} className={idx === 0 ? undefined : "border-b"}>
+                  <td className="p-2">
+                    <Skeleton
+                      className="h-4 w-36"
+                      label="Cargando cola de recordatorios"
+                      ariaHidden={idx > 0}
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-20" ariaHidden />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-16" ariaHidden />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-32" ariaHidden />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-12" ariaHidden />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-36" ariaHidden />
+                  </td>
+                  <td className="p-2">
+                    <Skeleton className="h-4 w-full" ariaHidden />
+                  </td>
+                </tr>
+              ))}
             {items.map((i) => (
               <tr key={i.id} className="border-b">
                 <td className="p-2">{new Date(i.created_at).toLocaleString()}</td>
@@ -119,8 +152,6 @@ export default function QueueTable() {
           </tbody>
         </table>
       </div>
-
-      {loading && <div className="p-3 text-sm text-slate-500">Cargando…</div>}
     </div>
   );
 }

--- a/components/reminders/Table.tsx
+++ b/components/reminders/Table.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
+import EmptyState from "@/components/EmptyState";
+import Skeleton from "@/components/ui/Skeleton";
+
 type Row = {
   id: string;
   patient_id: string | null;
@@ -24,6 +27,7 @@ export default function RemindersTable({ orgId }: { orgId: string }) {
     total: 0,
   });
   const [loading, setLoading] = useState(true);
+  const skeletonRows = Array.from({ length: 5 });
 
   const page = useMemo(() => Number(search.get("page") ?? 1), [search]);
   const pageSize = useMemo(() => Number(search.get("pageSize") ?? 50), [search]);
@@ -52,9 +56,11 @@ export default function RemindersTable({ orgId }: { orgId: string }) {
     };
   }, [orgId, search, page, pageSize]);
 
+  const showEmpty = !loading && rows.length === 0;
+
   return (
     <div className="rounded-2xl border overflow-hidden">
-      <table className="w-full text-sm">
+      <table className="w-full text-sm" aria-busy={loading}>
         <thead className="bg-gray-50">
           <tr>
             <th className="text-left px-3 py-2">Canal</th>
@@ -67,35 +73,64 @@ export default function RemindersTable({ orgId }: { orgId: string }) {
           </tr>
         </thead>
         <tbody>
-          {loading && (
+          {loading &&
+            skeletonRows.map((_, idx) => (
+              <tr key={`reminders-skeleton-${idx}`} className={idx === 0 ? undefined : "border-t"}>
+                <td className="px-3 py-3">
+                  <Skeleton
+                    className="h-4 w-24"
+                    label="Cargando recordatorios"
+                    ariaHidden={idx > 0}
+                  />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-24" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-32" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-40" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-28" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-28" ariaHidden />
+                </td>
+                <td className="px-3 py-3">
+                  <Skeleton className="h-4 w-12" ariaHidden />
+                </td>
+              </tr>
+            ))}
+          {!loading &&
+            rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="px-3 py-2">{r.channel ?? "—"}</td>
+                <td className="px-3 py-2">{r.status ?? "—"}</td>
+                <td className="px-3 py-2">{r.target ?? "—"}</td>
+                <td className="px-3 py-2">{r.template ?? "—"}</td>
+                <td className="px-3 py-2">
+                  {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
+                </td>
+                <td className="px-3 py-2">
+                  {r.last_attempt_at ? new Date(r.last_attempt_at).toLocaleString() : "—"}
+                </td>
+                <td className="px-3 py-2">{r.attempts ?? 0}</td>
+              </tr>
+            ))}
+          {showEmpty && (
             <tr>
-              <td colSpan={7} className="px-3 py-6 text-center">
-                Cargando…
+              <td colSpan={7} className="px-3 py-8">
+                <EmptyState
+                  emoji="📨"
+                  title="Sin recordatorios"
+                  hint="Todavía no se han enviado recordatorios con los filtros seleccionados."
+                  className="mx-auto max-w-md border border-dashed border-border bg-transparent shadow-none"
+                />
               </td>
             </tr>
           )}
-          {!loading && rows.length === 0 && (
-            <tr>
-              <td colSpan={7} className="px-3 py-6 text-center">
-                Sin resultados.
-              </td>
-            </tr>
-          )}
-          {rows.map((r) => (
-            <tr key={r.id} className="border-t">
-              <td className="px-3 py-2">{r.channel ?? "—"}</td>
-              <td className="px-3 py-2">{r.status ?? "—"}</td>
-              <td className="px-3 py-2">{r.target ?? "—"}</td>
-              <td className="px-3 py-2">{r.template ?? "—"}</td>
-              <td className="px-3 py-2">
-                {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
-              </td>
-              <td className="px-3 py-2">
-                {r.last_attempt_at ? new Date(r.last_attempt_at).toLocaleString() : "—"}
-              </td>
-              <td className="px-3 py-2">{r.attempts ?? 0}</td>
-            </tr>
-          ))}
         </tbody>
       </table>
 

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -2,17 +2,28 @@
 
 import * as React from "react";
 
+type SkeletonProps = {
+  className?: string;
+  label?: string;
+  /**
+   * Oculta el skeleton de lectores de pantalla cuando ya existe otro
+   * elemento con información del estado de carga.
+   */
+  ariaHidden?: boolean;
+};
+
 export default function Skeleton({
   className = "",
   label = "Cargando",
-}: {
-  className?: string;
-  label?: string;
-}) {
+  ariaHidden = false,
+}: SkeletonProps) {
+  const accessibilityProps = ariaHidden
+    ? { "aria-hidden": true }
+    : { role: "status", "aria-label": label };
+
   return (
     <div
-      role="status"
-      aria-label={label}
+      {...accessibilityProps}
       className={["animate-pulse rounded-xl bg-slate-200/80 dark:bg-slate-700/70", className].join(
         " ",
       )}


### PR DESCRIPTION
## Summary
- update the global focus-visible outline to use the shared ring color and add a soft halo
- expose an ariaHidden option on the Skeleton component and label icon-only buttons in the theme toggle
- render skeleton placeholders and richer empty states in patient, reminder, and bank tables while data loads

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd999cb67c832a928331afbf95940d