### PR TITLE
Add minimal tooltip UI component

### DIFF
--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Props = React.HTMLAttributes<HTMLDivElement> & { text: string };
+export function Tooltip({ text, className, children, ...props }: Props) {
+  return (
+    <div className={cn("relative inline-block group", className)} {...props}>
+      {children}
+      <div
+        role="tooltip"
+        className={cn(
+          "pointer-events-none absolute z-50 -translate-x-1/2 left-1/2 mt-2",
+          "rounded-md bg-foreground text-background text-xs px-2 py-1",
+          "opacity-0 group-hover:opacity-100 transition ease-soft"
+        )}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable Tooltip component with hover styles for displaying helper text

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9fbfc4ac832a8ffd48dd8223d686