### PR TITLE
Add shared empty state component and improve transaction table loading

### DIFF
--- a/components/bank/TxTable.tsx
+++ b/components/bank/TxTable.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
-import EmptyState from "@/components/ui/EmptyState";
+import { EmptyState } from "@/components/ui/empty-state";
+import Skeleton from "@/components/ui/Skeleton";
 
 type Tx = {
   id: string;
@@ -120,11 +121,12 @@ export default function TxTable({ orgId }: { orgId: string }) {
 
       {isEmpty ? (
         <EmptyState
-          emoji="🧾"
           title="Sin transacciones"
-          hint="Conecta tu banco o importa movimientos CSV para verlos aquí."
-          ctaText="Conectar banco"
-          onCta={() => window.location.assign("/banco/ajustes")}
+          description="Conecta tu banco o importa movimientos CSV para verlos aquí."
+          action={{
+            label: "Conectar banco",
+            onClick: () => window.location.assign("/banco/ajustes"),
+          }}
         />
       ) : (
         <>
@@ -142,9 +144,11 @@ export default function TxTable({ orgId }: { orgId: string }) {
               <tbody>
                 {loading && (
                   <tr>
-                    <td className="px-3 py-6 text-center" colSpan={5}>
-                      Cargando…
-                    </td>
+                    {[0, 1, 2, 3, 4].map((key) => (
+                      <td key={key} className="px-3 py-4">
+                        <Skeleton className="h-5 w-28" />
+                      </td>
+                    ))}
                   </tr>
                 )}
                 {!loading && rows.length === 0 && (

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,26 @@
+// components/ui/empty-state.tsx
+import { Button } from "@/components/ui/button";
+
+export function EmptyState({
+  title = "Sin resultados",
+  description = "Intenta ajustar los filtros o crear un nuevo elemento.",
+  action,
+}: {
+  title?: string;
+  description?: string;
+  action?: { label: string; onClick: () => void } | null;
+}) {
+  return (
+    <div className="text-center py-16 border border-dashed border-border rounded-xl">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="text-sm text-muted-foreground mt-1">{description}</p>
+      {action && (
+        <div className="mt-4">
+          <Button onClick={action.onClick} variant="primary">
+            {action.label}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable EmptyState UI component with optional primary action
- update the transactions table to use the new empty state and skeleton placeholders during loading

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9fcd5b48832a93617ea580259595