### PR TITLE
Actualizar navbar y copy RLS

### DIFF
--- a/app/api/reminders/templates/upsert/route.ts
+++ b/app/api/reminders/templates/upsert/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
   try {
     const supa = await getSupabaseServer();
 
-    // Usuario autenticado (RLS)
+    // Usuario autenticado. Solo se muestran pacientes de tu organización.
     const { data: u } = await supa.auth.getUser();
     if (!u?.user) {
       return NextResponse.json(

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,53 +1,76 @@
+// components/Navbar.tsx
 "use client";
+
 import Link from "next/link";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
 import OrgSwitcherBadge from "./OrgSwitcherBadge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Menu } from "lucide-react";
+
+const links = [
+  { href: "/dashboard", label: "Inicio" },
+  { href: "/consultorio", label: "Consultorio" },
+  { href: "/pacientes", label: "Pacientes" },
+  { href: "/especialidades", label: "Especialidades" },
+  { href: "/reportes/agenda/risk-pacientes", label: "Reportes" },
+];
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-sm">
-      <nav className="container h-[64px] flex items-center gap-3">
+    <header className="sticky top-0 z-50 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b border-border shadow-sm">
+      <div className="container h-16 flex items-center gap-3">
         <div className="flex items-center gap-3">
-          <OrgSwitcherBadge />
-          <Link href="/" className="font-bold text-lg" aria-label="Inicio Sanoa">
-            Sanoa
+          <button
+            className="md:hidden inline-flex items-center justify-center rounded-md h-10 w-10 border border-transparent hover:border-border"
+            aria-label="Abrir menú"
+            onClick={() => setOpen((v) => !v)}
+          >
+            <Menu className="emoji" size={20} />
+          </button>
+          <Link href="/" className="font-bold text-lg leading-none">
+            Sanoa<span className="text-primary">Lab</span>
           </Link>
         </div>
 
-        <div className="ml-auto hidden md:flex items-center gap-6">
-          <Link href="/consultorio" className="text-sm hover:opacity-80">Consultorio</Link>
-          <Link href="/pacientes" className="text-sm hover:opacity-80">Pacientes</Link>
-          <Link href="/especialidades" className="text-sm hover:opacity-80">Especialidades</Link>
-          <Link href="/banco" className="text-sm hover:opacity-80">Banco</Link>
-          <Button asChild variant="primary" size="md" className="font-bold">
-            <Link href="/signup">Crear cuenta</Link>
+        <nav className={cn("hidden md:flex items-center gap-4 ml-4")}>
+          {links.map((l) => (
+            <Link key={l.href} href={l.href} className="text-sm hover:underline underline-offset-4">
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-2">
+          <OrgSwitcherBadge />
+          <Button asChild variant="primary" className="hidden sm:inline-flex">
+            <Link href="/prescriptions/templates">Nueva receta</Link>
           </Button>
         </div>
+      </div>
 
-        {/* Mobile */}
-        <button
-          className="md:hidden btn-base ghost"
-          aria-label="Menú"
-          onClick={() => setOpen((s) => !s)}
-        >
-          ☰
-        </button>
-      </nav>
-
+      {/* Mobile nav */}
       {open && (
-        <div className="md:hidden border-t border-border bg-background">
-          <div className="container py-3 flex flex-col gap-2">
-            <Link href="/consultorio" className="py-2">Consultorio</Link>
-            <Link href="/pacientes" className="py-2">Pacientes</Link>
-            <Link href="/especialidades" className="py-2">Especialidades</Link>
-            <Link href="/banco" className="py-2">Banco</Link>
-            <Button asChild variant="primary" className="mt-1">
-              <Link href="/signup">Crear cuenta</Link>
-            </Button>
-          </div>
+        <div className="md:hidden border-t border-border bg-card">
+          <nav className="container py-2 grid">
+            {links.map((l) => (
+              <Link
+                key={l.href}
+                href={l.href}
+                className="px-1 py-2 text-sm border-b last:border-b-0 border-border"
+                onClick={() => setOpen(false)}
+              >
+                {l.label}
+              </Link>
+            ))}
+            <div className="pt-3 pb-2">
+              <Button asChild variant="primary" className="w-full" onClick={() => setOpen(false)}>
+                <Link href="/prescriptions/templates">Nueva receta</Link>
+              </Button>
+            </div>
+          </nav>
         </div>
       )}
     </header>

--- a/components/bank/RulesEditor.tsx
+++ b/components/bank/RulesEditor.tsx
@@ -40,11 +40,11 @@ export default function RulesEditor() {
     let alive = true;
     async function run() {
       setLoading(true);
-      // reglas por API (RLS por sesión)
+      // reglas por API. Solo se muestran pacientes de tu organización.
       const r = await fetch(`/api/bank/rules?org_id=${orgId}`)
         .then((r) => r.json())
         .catch(() => ({ ok: false }));
-      // categorías desde Supabase browser client (RLS)
+      // categorías desde Supabase browser client. Solo se muestran pacientes de tu organización.
       const supa = getSupabaseBrowser();
       const { data: catData } = await supa
         .from("bank_categories")


### PR DESCRIPTION
## Summary
- reemplazar la barra de navegación por una versión sticky con menú móvil y CTA unificados
- añadir la clase emoji al icono del menú móvil para mantener consistencia visual
- actualizar las referencias de copy (RLS) por el mensaje "Solo se muestran pacientes de tu organización." en comentarios relevantes

## Testing
- pnpm lint *(falla por problemas existentes en app/api/bank/checkout/route.ts y otros archivos no modificados en este cambio)*

------
https://chatgpt.com/codex/tasks/task_e_68dda484571c832aae524a4940d1934d