### PR TITLE
Add redirect from areas to especialidades

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -28,6 +28,12 @@ function getIp(req: NextRequest) {
 }
 
 export function middleware(req: NextRequest) {
+  const url = req.nextUrl.clone();
+  if (url.pathname === "/areas") {
+    url.pathname = "/especialidades";
+    return NextResponse.redirect(url);
+  }
+
   if (!DISABLED) {
     const ip = getIp(req);
     const key = `${ip}:${new URL(req.url).pathname}`;
@@ -47,12 +53,6 @@ export function middleware(req: NextRequest) {
       bucket.count += 1;
       buckets.set(key, bucket);
     }
-  }
-
-  const url = req.nextUrl.clone();
-  if (url.pathname === "/areas") {
-    url.pathname = "/especialidades";
-    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- add a middleware redirect that sends requests for /areas to /especialidades before running rate limiting

## Testing
- pnpm lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dda5106484832a9e9d9f2a00c2c71c