### PR TITLE
Update checkout link and add reminders table suspense

### DIFF
--- a/app/(app)/especialidades/page.tsx
+++ b/app/(app)/especialidades/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
                 <Link href={`/modules/${it.key}/overview`}>Ver módulo</Link>
               </Button>
               <Button asChild variant="ghost">
-                <Link href="/banco">Desbloquear con Sanoa Bank</Link>
+                <Link href="/banco/checkout">Desbloquear con Sanoa Bank</Link>
               </Button>
             </CardContent>
           </Card>

--- a/app/(app)/recordatorios/page.tsx
+++ b/app/(app)/recordatorios/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 
 import AccentHeader from "@/components/ui/AccentHeader";
@@ -11,6 +11,7 @@ import ColorEmoji from "@/components/ColorEmoji";
 import SavedViewsBar from "@/components/saved-views/SavedViewsBar";
 import RemindersFilters from "@/components/reminders/Filters";
 import RemindersTable from "@/components/reminders/Table";
+import { TableLoader } from "@/components/ui/states";
 import { getActiveOrg } from "@/lib/org-local";
 
 export default function RecordatoriosPage() {
@@ -110,7 +111,9 @@ export default function RecordatoriosPage() {
           </div>
 
           <RemindersFilters />
-          <RemindersTable orgId={orgId} />
+          <Suspense fallback={<TableLoader />}>
+            <RemindersTable orgId={orgId} />
+          </Suspense>
         </section>
       )}
     </main>


### PR DESCRIPTION
## Summary
- point the specialties unlock button to the direct banco checkout route
- wrap the reminders table in a Suspense boundary with the shared table loader fallback

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dda88a1450832ab8452790f25cefb5