### PR TITLE
Add OrgInspector component with embedded switcher

### DIFF
--- a/components/shared/OrgInspector.tsx
+++ b/components/shared/OrgInspector.tsx
@@ -1,32 +1,50 @@
+// components/shared/OrgInspector.tsx
 "use client";
 
-// Conserva compatibilidad: export por defecto del inspector existente
-export { default } from "@/components/organizations/ActiveOrgInspector";
-
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import OrgSwitcherBadge from "@/components/OrgSwitcherBadge";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 
-// Export nombrado opcional con la UI en tarjeta
-export function OrgInspector({ ctaHref = "/ajustes" }: { ctaHref?: string }) {
-  return (
-    <Card className="card-hover">
-      <CardHeader>
-        <CardTitle>Selecciona una organización activa</CardTitle>
-        <CardDescription>Elige o cambia tu organización para continuar.</CardDescription>
-      </CardHeader>
-      <CardContent className="flex items-center justify-between gap-3">
+type Props = {
+  children?: ReactNode;
+  title?: string;
+  description?: string;
+};
+
+export default function OrgInspector({
+  children,
+  title = "Selecciona una organización activa para continuar.",
+  description = "El contenido se habilita cuando eliges una organización en el switcher.",
+}: Props) {
+  const [ready, setReady] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch("/api/orgs/features/check", { cache: "no-cache" });
+        // Si 200, asumimos que hay org activa (o el endpoint responde con algo útil).
+        if (!cancelled) setReady(r.ok);
+      } catch {
+        if (!cancelled) setReady(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (ready === null) {
+    return <div className="skeleton h-12 w-full" />;
+  }
+
+  if (!ready) {
+    return (
+      <div className="rounded-lg border border-border p-4 bg-card">
+        <div className="text-base font-semibold mb-1">{title}</div>
+        <div className="text-sm text-muted-foreground mb-3">{description}</div>
         <OrgSwitcherBadge />
-        <Button asChild variant="primary">
-          <a href={ctaHref}>Elegir organización</a>
-        </Button>
-      </CardContent>
-    </Card>
-  );
+      </div>
+    );
+  }
+
+  return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- add a client-side OrgInspector wrapper that checks for an active organization
- show a skeleton while validating and prompt users to select an organization with the embedded switcher badge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda8dfd89c832aae6ebe7ebf113fac