### PR TITLE
Replace Blob PDF responses with Response

### DIFF
--- a/app/api/branding/preview/rx/pdf/route.ts
+++ b/app/api/branding/preview/rx/pdf/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 // MODE: session (user-scoped, cookies)
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
 import { jsonError } from "@/lib/http/validate";
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
@@ -157,7 +157,7 @@ export async function GET(req: NextRequest) {
   }
 
   const bytes = await pdf.save();
-  return new NextResponse(bytes, {
+  return new Response(bytes as any, {
     status: 200,
     headers: {
       "content-type": "application/pdf",

--- a/app/api/discharges/[id]/pdf/route.ts
+++ b/app/api/discharges/[id]/pdf/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 // MODE: session (user-scoped, cookies)
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
 import { jsonError, readOrgIdFromQuery } from "@/lib/http/validate";
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
@@ -42,7 +42,7 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
   const bytes = await pdf.save();
   const filename = `alta_${id}.pdf`;
 
-  return new NextResponse(bytes, {
+  return new Response(bytes as any, {
     status: 200,
     headers: {
       "content-type": "application/pdf",

--- a/app/api/labs/requests/[id]/pdf/route.ts
+++ b/app/api/labs/requests/[id]/pdf/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { newPdf, pngFromDataUrl, makeQrDataUrl, drawWrappedText } from "@/lib/pdf";
 import { badRequest, unauthorized, notFound, dbError, serverError } from "@/lib/api/responses";
 import { getSupabaseServer } from "@/lib/supabase/server";
@@ -202,10 +202,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
     const bytes = await pdf.save();
 
-    // 👇 Envolvemos Uint8Array en un Blob para que TS/Fetch lo acepte sin queja
-    const blob = new Blob([bytes], { type: "application/pdf" });
-
-    return new NextResponse(new Blob([blob]), {
+    return new Response(bytes as any, {
       status: 200,
       headers: {
         "Content-Type": "application/pdf",

--- a/app/api/patients/[id]/pdf/route.ts
+++ b/app/api/patients/[id]/pdf/route.ts
@@ -127,10 +127,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     const bytes = await pdf.save();
     const filename = `paciente_${patient.id}.pdf`;
 
-    // ⚠️ Importante: envolver Uint8Array en Blob para evitar error de TS con Response
-    const blob = new Blob([bytes], { type: "application/pdf" });
-
-    return new Response(new Blob([blob]), {
+    return new Response(bytes as any, {
       headers: {
         "Content-Type": "application/pdf",
         "Content-Disposition": `attachment; filename="${filename}"`,

--- a/app/api/prescriptions/[id]/pdf/route.ts
+++ b/app/api/prescriptions/[id]/pdf/route.ts
@@ -1,6 +1,6 @@
 // app/api/prescriptions/[id]/pdf/route.ts
 // MODE: session (user-scoped, cookies)
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
 import { jsonError, readOrgIdFromQuery } from "@/lib/http/validate";
 import { PDFDocument, StandardFonts, rgb, type RGB } from "pdf-lib";
@@ -249,7 +249,7 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
   const filename = `receta_${rx.folio ?? rx.id}.pdf`;
 
   // ⬇️ Buffer en lugar de Blob (evita TS2322)
-  return new NextResponse(bytes, {
+  return new Response(bytes as any, {
     status: 200,
     headers: {
       "content-type": "application/pdf",

--- a/app/api/prescriptions/[id]/pdf2/route.ts
+++ b/app/api/prescriptions/[id]/pdf2/route.ts
@@ -217,8 +217,8 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
 
   const pdfBytes = await pdf.save();
 
-  // ✅ Body como Blob para satisfacer BodyInit (TS) en Response/NextResponse
-  return new Response(pdfBytes, {
+  // ✅ Body como Uint8Array casteado para satisfacer BodyInit en Response
+  return new Response(pdfBytes as any, {
     status: 200,
     headers: {
       "content-type": "application/pdf",

--- a/app/api/reports/agenda/summary/pdf/route.ts
+++ b/app/api/reports/agenda/summary/pdf/route.ts
@@ -189,10 +189,7 @@ export async function GET(req: NextRequest) {
     const bytes = await pdf.save();
     const filename = `agenda_resumen_${org_id}_${from}_${to}.pdf`;
 
-    // ✅ Envolver Uint8Array en Blob para Response (TS feliz)
-    const blob = new Blob([bytes], { type: "application/pdf" });
-
-    return new Response(bytes, {
+    return new Response(bytes as any, {
       headers: {
         "content-type": "application/pdf",
         "content-disposition": `attachment; filename="${filename}"`,


### PR DESCRIPTION
## Summary
- update PDF-generating API routes to return `Response` with the PDF bytes instead of wrapping them in `Blob` or `NextResponse`
- remove now-unused `NextResponse` imports where the JSON helpers cover error responses

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e0836d6afc832a94f77a76987da310