### PR TITLE
Fix subscription status handler typings

### DIFF
--- a/app/api/billing/subscription/status/route.ts
+++ b/app/api/billing/subscription/status/route.ts
@@ -14,17 +14,18 @@ export async function GET(req: Request) {
     .maybeSingle();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  const status = data?.stripe_status ?? null;
+  const d: any = data;
+  const status = d?.stripe_status ?? null;
   const active = typeof status === "string" && ["active", "trialing", "past_due"].includes(status);
-  const modules = (data?.modules as Record<string, boolean> | null) ?? {};
-  const bankReady = Boolean((data as { bank_ready?: boolean | null } | null)?.bank_ready);
+  const modules = (d?.modules as Record<string, boolean> | null) ?? {};
+  const bankReady = Boolean(d?.bank_ready ?? null);
 
   return NextResponse.json({
     ok: true,
     data: {
       stripe_status: status,
-      current_period_end: data?.current_period_end ?? null,
-      stripe_customer_id: data?.stripe_customer_id ?? null,
+      current_period_end: d?.current_period_end ?? null,
+      stripe_customer_id: d?.stripe_customer_id ?? null,
       active,
       modules,
       bank_ready: bankReady,


### PR DESCRIPTION
## Summary
- cast the Supabase subscription payload to allow access to optional fields
- preserve fallbacks for subscription status, modules, and customer identifiers while keeping bank readiness detection intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e084abca70832aaed0dbf8f27d58fb