### PR TITLE
Refine emoji usage and simplify theme imports

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -15,18 +15,22 @@ export default function Error({ error, reset }: ErrorProps) {
   return (
     <Card className="mx-auto mt-12 max-w-xl space-y-4 text-center">
       <div className="text-6xl">
-        <Emoji size={24} glyph="🛠️" />
+        <Emoji size={24}>🛠️</Emoji>
       </div>
       <h1>Algo no salió bien</h1>
       <p className="text-muted-foreground">{error?.message ?? "Error inesperado."}</p>
       <div className="flex justify-center gap-3 pt-2">
         <Button type="button" variant="secondary" onClick={() => reset()}>
-          <Emoji size={24} className="mr-1" glyph="🔁" />
+          <Emoji size={24} className="mr-1">
+            🔁
+          </Emoji>
           Reintentar
         </Button>
         <Button asChild>
           <Link href="/dashboard">
-            <Emoji size={24} className="mr-1" glyph="📊" />
+            <Emoji size={24} className="mr-1">
+              📊
+            </Emoji>
             Ir al tablero
           </Link>
         </Button>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -8,20 +8,24 @@ export default function NotFound() {
   return (
     <Card className="mx-auto mt-12 max-w-xl space-y-4 text-center">
       <div className="text-6xl">
-        <Emoji size={24} glyph="🧭" />
+        <Emoji size={24}>🧭</Emoji>
       </div>
       <h1>Página no encontrada (404)</h1>
       <p className="text-muted-foreground">Uy… no pudimos encontrar lo que buscas.</p>
       <div className="flex justify-center gap-3 pt-2">
         <Button asChild variant="secondary">
           <Link href="/">
-            <Emoji size={24} className="mr-1" glyph="🏠" />
+            <Emoji size={24} className="mr-1">
+              🏠
+            </Emoji>
             Inicio
           </Link>
         </Button>
         <Button asChild>
           <Link href="/dashboard">
-            <Emoji size={24} className="mr-1" glyph="📊" />
+            <Emoji size={24} className="mr-1">
+              📊
+            </Emoji>
             Ir al dashboard
           </Link>
         </Button>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { ThemeProvider } from "@/lib/next-themes";
+import { ThemeProvider } from "next-themes";
 import { ToastProvider } from "@/components/Toast";
 import RegisterSW from "@/components/RegisterSW";
 import Toaster from "@/components/Toaster";

--- a/components/Emoji.tsx
+++ b/components/Emoji.tsx
@@ -3,23 +3,19 @@
 import type { HTMLAttributes, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-type EmojiSize = "sm" | "md" | "lg";
-
-const sizeMap: Record<EmojiSize, string> = {
-  sm: "text-[1.1em]",
-  md: "text-[1.35em]",
-  lg: "text-[1.6em]",
-};
-
 interface EmojiProps extends HTMLAttributes<HTMLSpanElement> {
   className?: string;
   children: ReactNode;
-  size?: EmojiSize;
+  size?: number;
 }
 
-export default function Emoji({ className, children, size = "md", ...props }: EmojiProps) {
+export default function Emoji({ className, children, size = 20, style, ...props }: EmojiProps) {
   return (
-    <span className={cn("emoji align-[0.05em]", sizeMap[size], className)} {...props}>
+    <span
+      className={cn("emoji align-[0.05em]", className)}
+      style={{ fontSize: size, ...style }}
+      {...props}
+    >
       {children}
     </span>
   );

--- a/components/Toaster.tsx
+++ b/components/Toaster.tsx
@@ -24,7 +24,7 @@ export default function Toaster() {
         return (
           <Card key={toast.id} className="min-w-[260px] flex items-start gap-3 bg-background/90 shadow-card backdrop-blur">
             <div className="text-2xl">
-              <Emoji size={24} glyph={emoji} />
+              <Emoji size={24}>{emoji}</Emoji>
             </div>
             <div className="flex-1 space-y-1">
               {toast.title && <div className="font-semibold text-sm uppercase tracking-wide text-muted-foreground/70">{toast.title}</div>}

--- a/components/prescriptions/TemplateEditorModal.tsx
+++ b/components/prescriptions/TemplateEditorModal.tsx
@@ -61,7 +61,7 @@ export default function TemplateEditorModal({ open, onClose, initial, onSaved }:
       onClose={onClose}
       title={
         <div className="flex items-center gap-2">
-          <Emoji size="lg" glyph="🧪" /> Editar plantilla
+          <Emoji size={24}>🧪</Emoji> Editar plantilla
         </div>
       }
       footer={

--- a/lib/next-themes.tsx
+++ b/lib/next-themes.tsx
@@ -1,2 +1,0 @@
-export { ThemeProvider } from "next-themes";
-export type { ThemeProviderProps } from "next-themes";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "preserve",
     "incremental": true,
     "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./*"], "next-themes": ["./lib/next-themes"] },
+    "paths": { "@/*": ["./*"] },
     "baseUrl": "."
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/types/emoji-props.d.ts
+++ b/types/emoji-props.d.ts
@@ -1,16 +1,6 @@
-declare module "@/components/Emoji" {
-  import * as React from "react";
-
-  export type Props = {
-    emoji?: string;
-    size?: number;
-    mode?: string;
-    color?: string;
-    accentColor?: string;
-    className?: string;
-    title?: string;
-  };
-
-  const Emoji: React.FC<Props>;
-  export default Emoji;
-}
+import { ReactNode } from "react";
+export type Props = {
+  size?: number;
+  className?: string;
+  children?: ReactNode;
+};


### PR DESCRIPTION
## Summary
- update the Emoji component to use children with numeric sizing and refresh its type definition
- adjust Emoji usage across error, not-found, toaster, and template editor views to the new API
- remove the lib/next-themes wrapper in favor of direct imports and clean up path aliases

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e084967414832a9aef7c48d20337d9