### PR TITLE
Relax Supabase client typing

### DIFF
--- a/app/api/bank/portal/route.ts
+++ b/app/api/bank/portal/route.ts
@@ -25,10 +25,11 @@ export async function POST(req: NextRequest) {
 
     // Busca el customer vinculado a la organización
     const supa = createServiceClient();
-    const { data, error } = await supa
-      .from<any>("org_billing" as any)
+    const supaAny = supa as any;
+    const { data, error } = await supaAny
+      .from("org_billing")
       .select("stripe_customer_id")
-      .eq("org_id", org_id)
+      .eq("org_id" as any, org_id as any)
       .single();
 
     if (error || !data?.stripe_customer_id) {

--- a/app/api/billing/stripe/webhook/route.ts
+++ b/app/api/billing/stripe/webhook/route.ts
@@ -34,14 +34,15 @@ export async function POST(req: Request) {
 
       if (org_id) {
         const supa = createServiceClient();
+        const supaAny = supa as any;
 
         if (product) {
           const patch: Record<string, unknown> = { org_id, [product]: true };
-          await supa.from<any>("org_features" as any).upsert(patch, { onConflict: "org_id" });
+          await supaAny.from("org_features").upsert(patch, { onConflict: "org_id" });
         }
 
-        await supa
-          .from<any>("org_billing" as any)
+        await supaAny
+          .from("org_billing")
           .upsert(
             { org_id, stripe_customer_id: customer, stripe_subscription_id: subscription },
             { onConflict: "org_id" },

--- a/app/api/branding/preview/rx/pdf/route.ts
+++ b/app/api/branding/preview/rx/pdf/route.ts
@@ -19,6 +19,7 @@ async function fetchAsUint8(url: string): Promise<Uint8Array | null> {
 
 export async function GET(req: NextRequest) {
   const supa = await getSupabaseServer();
+  const supaAny = supa as any;
   const qp = new URL(req.url).searchParams;
   const org_id = qp.get("org_id") ?? undefined;
   if (!org_id) return jsonError("BAD_REQUEST", "Falta org_id", 400);
@@ -27,11 +28,11 @@ export async function GET(req: NextRequest) {
   const provider_id = qp.get("provider_id") ?? me?.user?.id ?? null;
   if (!provider_id) return jsonError("UNAUTHORIZED", "No provider", 401);
 
-  const { data: pb, error } = await supa
-    .from<any>("provider_branding" as any)
+  const { data: pb, error } = await supaAny
+    .from("provider_branding")
     .select("*")
-    .eq("org_id", org_id)
-    .eq("provider_id", provider_id)
+    .eq("org_id" as any, org_id as any)
+    .eq("provider_id" as any, provider_id as any)
     .maybeSingle();
   if (error) return jsonError("DB_ERROR", error.message, 400);
 

--- a/app/api/lab/templates/list/route.ts
+++ b/app/api/lab/templates/list/route.ts
@@ -6,6 +6,7 @@ type OwnerKind = "user" | "org";
 
 export async function GET(req: NextRequest) {
   const supa = await getSupabaseServer();
+  const supaAny = supa as any;
 
   try {
     const { data: auth } = await supa.auth.getUser();
@@ -21,19 +22,19 @@ export async function GET(req: NextRequest) {
       return badRequest("org_id requerido");
     }
 
-    let query = supa
-      .from<any>("lab_templates" as any)
+    let query = supaAny
+      .from("lab_templates")
       .select("id, org_id, owner_kind, owner_id, title, items, is_active, created_at")
-      .eq("org_id", orgId)
-      .eq("is_active", true)
+      .eq("org_id" as any, orgId as any)
+      .eq("is_active" as any, true as any)
       .order("created_at", { ascending: false });
 
     if (owner === "user") {
-      query = query.eq("owner_kind", "user").eq("owner_id", auth.user.id);
+      query = query.eq("owner_kind" as any, "user" as any).eq("owner_id" as any, auth.user.id as any);
     }
 
     if (owner === "org") {
-      query = query.eq("owner_kind", "org");
+      query = query.eq("owner_kind" as any, "org" as any);
     }
 
     const { data, error } = await query;

--- a/app/api/lab/templates/upsert/route.ts
+++ b/app/api/lab/templates/upsert/route.ts
@@ -26,6 +26,7 @@ const schema = z.object({
 
 export async function POST(req: NextRequest) {
   const supa = await getSupabaseServer();
+  const supaAny = supa as any;
 
   try {
     const { data: auth } = await supa.auth.getUser();
@@ -51,13 +52,13 @@ export async function POST(req: NextRequest) {
     };
 
     if (id) {
-      let query = supa
-        .from<any>("lab_templates" as any)
+      let query = supaAny
+        .from("lab_templates")
         .update(payload)
-        .eq("id", id)
-        .eq("org_id", org_id);
+        .eq("id" as any, id as any)
+        .eq("org_id" as any, org_id as any);
       if (owner_kind === "user") {
-        query = query.eq("owner_id", auth.user.id);
+        query = query.eq("owner_id" as any, auth.user.id as any);
       }
 
       const { error } = await query;
@@ -68,8 +69,8 @@ export async function POST(req: NextRequest) {
       return ok({ id });
     }
 
-    const { data, error } = await supa
-      .from<any>("lab_templates" as any)
+    const { data, error } = await supaAny
+      .from("lab_templates")
       .insert(payload)
       .select("id")
       .single();

--- a/app/api/work/events/route.ts
+++ b/app/api/work/events/route.ts
@@ -13,6 +13,7 @@ const BodySchema = z.object({
 
 export async function POST(req: NextRequest) {
   const supa = await getSupabaseServer();
+  const supaAny = supa as any;
   const body = await parseJson(req);
   const parsed = parseOrError(BodySchema, body);
   if (!parsed.ok) return jsonError(parsed.error.code, parsed.error.message, 400);
@@ -20,7 +21,7 @@ export async function POST(req: NextRequest) {
   const { data: me } = await supa.auth.getUser();
   const actor = me?.user?.id ?? null;
 
-  const { error: e1 } = await supa.from<any>("work_events" as any).insert({
+  const { error: e1 } = await supaAny.from("work_events").insert({
     org_id: parsed.data.org_id,
     assignment_id: parsed.data.assignment_id,
     kind: parsed.data.kind,
@@ -31,10 +32,10 @@ export async function POST(req: NextRequest) {
 
   // Si es completado, marca en assignment
   if (parsed.data.kind === "completed") {
-    const { error: e2 } = await supa
-      .from<any>("work_assignments" as any)
+    const { error: e2 } = await supaAny
+      .from("work_assignments")
       .update({ last_done_at: new Date().toISOString(), status: "completed" })
-      .eq("id", parsed.data.assignment_id);
+      .eq("id" as any, parsed.data.assignment_id as any);
     if (e2) return jsonError("DB_ERROR", e2.message, 400);
   }
 


### PR DESCRIPTION
## Summary
- cast Supabase clients to `any` in API routes that were relying on broken generic definitions
- update all `from` and `eq` calls to use the relaxed client to avoid strict type argument errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0897a8900832aa14f895ddc512bf1