### PR TITLE
Handle optional fields in discharge and prescription PDFs

### DIFF
--- a/app/api/discharges/[id]/pdf/route.ts
+++ b/app/api/discharges/[id]/pdf/route.ts
@@ -21,7 +21,8 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
   const font = await pdf.embedFont(StandardFonts.Helvetica);
 
   page.drawText("ALTA MÉDICA", { x: 50, y: 800, size: 18, font, color: rgb(0, 0, 0) });
-  page.drawText(`Folio: ${dc.folio ?? dc.id}`, { x: 50, y: 780, size: 10, font });
+  const folio = (dc as any).folio ?? dc.id;
+  page.drawText(`Folio: ${folio}`, { x: 50, y: 780, size: 10, font });
   page.drawText(`Fecha: ${new Date(dc.created_at ?? Date.now()).toLocaleString()}`, {
     x: 50,
     y: 760,

--- a/app/api/prescriptions/[id]/pdf/route.ts
+++ b/app/api/prescriptions/[id]/pdf/route.ts
@@ -91,12 +91,11 @@ export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
 
   // Paciente
   let patientName = "Paciente";
-  const patientId = rx.patient_id ?? "";
-  {
+  if (rx.patient_id) {
     const { data: p } = await supa
       .from("patients")
-      .select("full_name")
-      .eq("id", rx.patient_id)
+      .select("full_name, external_id")
+      .eq("id" as any, rx.patient_id)
       .maybeSingle();
     if (p?.full_name) patientName = p.full_name;
   }


### PR DESCRIPTION
## Summary
- use a fallback folio value when discharges lack a typed folio field
- guard patient lookup in prescription PDFs when the patient id is absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e089d8737c832aa418bb27f4ad9723