### PR TITLE
Fix agreements Supabase queries and acceptance metadata

### DIFF
--- a/app/api/agreements/share/[token]/accept/route.ts
+++ b/app/api/agreements/share/[token]/accept/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest, { params }: { params: { token: stri
 
   const { data: tpl, error: eTpl } = await svc
     .from("agreements_templates")
-    .select("id, org_id, type, title, content, provider_id")
+    .select("id, org_id, type, version, title, content, provider_id")
     .eq("id", link.template_id)
     .single();
   if (eTpl) return jsonError("DB_ERROR", eTpl.message, 400);
@@ -46,10 +46,12 @@ export async function POST(req: NextRequest, { params }: { params: { token: stri
     signer_id: link.type === "specialist_platform" ? link.provider_id : link.patient_id,
     signer_name: p.data.full_name,
     accepted_at: new Date().toISOString(),
+    contract_type: (tpl as any)?.type ?? link.type,
+    template_version: (tpl as any)?.version ?? (link as any)?.template_version ?? null,
     snapshot: { title: tpl.title, content: tpl.content, selections: p.data.extra ?? {} },
     ip: req.headers.get("x-forwarded-for") || null,
     user_agent: req.headers.get("user-agent") || null,
-  };
+  } as any;
 
   const { error: eAcc } = await svc.from("agreements_acceptances").insert(acceptance);
   if (eAcc) return jsonError("DB_ERROR", eAcc.message, 400);

--- a/app/api/agreements/share/[token]/route.ts
+++ b/app/api/agreements/share/[token]/route.ts
@@ -5,16 +5,16 @@ import { jsonOk, jsonError } from "@/lib/http/validate";
 
 export async function GET(_req: NextRequest, { params }: { params: { token: string } }) {
   const svc = createServiceClient();
+  const supaAny = svc as any;
   const token = params.token;
 
-  const { data: link, error } = await svc
+  const { data: linkRow, error } = await supaAny
     .from("agreements_links")
-    .select(
-      "token, org_id, template_id, type, patient_id, provider_id, expires_at, used_at, status",
-    )
-    .eq("token", token)
-    .single();
-  if (error) return jsonError("NOT_FOUND", "Token inválido", 404);
+    .select("*")
+    .eq("token" as any, token)
+    .maybeSingle();
+  const link = linkRow as any;
+  if (error || !link) return jsonError("NOT_FOUND", "Token inválido", 404);
 
   const now = new Date();
   if (link.used_at) return jsonError("ALREADY_USED", "Este enlace ya fue utilizado", 410);


### PR DESCRIPTION
## Summary
- include contract metadata when logging agreement acceptances
- fetch agreement share tokens and creation data with `supaAny` casts to avoid type instantiation errors
- use `supaAny` for agreement template listing and upsert queries with the correct table name

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e089b14608832abb63f3b5b0646125