### PR TITLE
Ensure org_features upserts include feature_id key

### DIFF
--- a/app/api/billing/stripe/webhook/route.ts
+++ b/app/api/billing/stripe/webhook/route.ts
@@ -36,8 +36,8 @@ export async function POST(req: Request) {
         const supa = createServiceClient();
 
         if (product) {
-          const patch: Record<string, unknown> = { org_id, [product]: true };
-          await supa.from<any>("org_features" as any).upsert(patch, { onConflict: "org_id" });
+          const patch = { org_id, feature_id: product, [product]: true } as any;
+          await supa.from<any>("org_features" as any).upsert(patch, { onConflict: "org_id,feature_id" });
         }
 
         await supa

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
         // upsert en org_features activando la bandera del producto
         await supa
           .from("org_features")
-          .upsert({ org_id, [product]: true }, { onConflict: "org_id" });
+          .upsert({ org_id, feature_id: product, [product]: true }, { onConflict: "org_id,feature_id" });
       }
     }
 


### PR DESCRIPTION
## Summary
- update Stripe billing webhook to upsert org_features rows using the org_id+feature_id composite key
- align legacy Stripe webhook handler with the same composite key-based upsert

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e089f7bfe0832abb73a94174f34eb6