### PR TITLE
Use filter for reminder status query

### DIFF
--- a/lib/reminders/runner.ts
+++ b/lib/reminders/runner.ts
@@ -21,7 +21,7 @@ export async function runReminderBatch(orgId?: string, limit: any = 20) {
   let q = supa
     .from("reminders")
     .select("*").returns<any[]>()
-    .in("status", ["scheduled", "retry"])
+    .filter("status", "in", '("scheduled","retry")')
     .lte("next_run_at", now)
     .order("next_run_at", { ascending: true })
     .limit(limit);


### PR DESCRIPTION
## Summary
- replace the `in` helper with an explicit `filter` for reminder status selection to avoid type issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e08a067734832aa8d53f1b26016391