### PR TITLE
Refactor Segment track base64 helper

### DIFF
--- a/lib/segment/track.ts
+++ b/lib/segment/track.ts
@@ -23,9 +23,11 @@ const WRITE_KEY =
   process.env.SEGMENT_WRITE_KEY || process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY;
 
 /** Base64 en Node/Edge (fallback a Buffer en Node) */
+type MaybeBtoa = (input: string) => string;
+
 function b64encode(str: string): string {
-  // @ts-expect-error - razon: API legacy hasta migrar evento
-  if (typeof btoa === "function") return btoa(str);
+  const globalBtoa = (globalThis as { btoa?: MaybeBtoa }).btoa;
+  if (typeof globalBtoa === "function") return globalBtoa(str);
   // Node
   // eslint-disable-next-line n/no-deprecated-api
   return Buffer.from(str, "utf8").toString("base64");


### PR DESCRIPTION
## Summary
- remove the unused @ts-expect-error annotation in the Segment track helper
- guard access to the browser btoa implementation via globalThis to satisfy TypeScript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e08a299cd0832aba8cc71fd8eca1e8