### PR TITLE
Fix patient selector typing and auth field props

### DIFF
--- a/app/(app)/pacientes/[id]/laboratorio/[req]/page.tsx
+++ b/app/(app)/pacientes/[id]/laboratorio/[req]/page.tsx
@@ -70,7 +70,7 @@ export default function LabRequestDetailPage() {
         showToast({
           title: "OCR",
           description: "El OCR rápido funciona para imágenes (PNG/JPG). Para PDF lo veremos luego.",
-          variant: "secondary",
+          variant: "info",
         });
         return;
       }

--- a/app/(app)/print/equilibrio/planes/[id]/page.tsx
+++ b/app/(app)/print/equilibrio/planes/[id]/page.tsx
@@ -4,7 +4,7 @@ import AccentHeader from "@/components/ui/AccentHeader";
 export default async function PrintPlan({ params }: { params: { id: string } }) {
   const supa = await createClient();
   const { data } = await supa.from("exercise_plans").select("*").eq("id", params.id).single();
-  const plan = data?.plan || { items: [] };
+  const plan = ((data?.plan as { items?: any[] } | null) ?? { items: [] });
 
   return (
     <div className="p-8 print:p-0 max-w-2xl mx-auto text-sm">
@@ -13,7 +13,7 @@ export default async function PrintPlan({ params }: { params: { id: string } }) 
         {data?.title || "Sin título"} · Paciente: {data?.patient_id}
       </div>
       <ol className="list-decimal ml-6 space-y-1">
-        {(plan.items || []).map((it: any, idx: number) => (
+        {(plan.items ?? []).map((it: any, idx: number) => (
           <li key={idx}>
             {it.name} — {it.sets}×{it.reps} · {it.freqPerWeek}/sem{it.notes ? ` · ${it.notes}` : ""}
           </li>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -217,7 +217,6 @@ function Inner() {
                 value={email}
                 onChange={(e: any) => setEmail(e.target.value)}
                 placeholder="tucorreo@ejemplo.com"
-                invalid={Boolean(emailError)}
               />
             </Field>
 

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { getSupabaseClient } from "@/lib/supabase/client";
+import { supa as supabaseClient } from "@/lib/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -20,7 +20,7 @@ export default function RegisterPage() {
     setLoading(true);
     setMsg(null);
     try {
-      const supabase = getSupabaseClient();
+      const supabase = supabaseClient;
       const { data, error } = await supabase.auth.signUp({
         email,
         password: pass,

--- a/app/(auth)/reset-password/change/page.tsx
+++ b/app/(auth)/reset-password/change/page.tsx
@@ -70,7 +70,7 @@ export default function ChangePasswordPage() {
               value={pass}
               onChange={(e: any) => setPass(e.target.value)}
               placeholder="••••••••"
-              invalid={Boolean(err)}
+              aria-invalid={err ? true : undefined}
               aria-describedby={err ? "change-password-error" : undefined}
             />
           </Field>

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -68,7 +68,7 @@ export default function ResetPasswordPage() {
               value={email}
               onChange={(e: any) => setEmail(e.target.value)}
               placeholder="tucorreo@ejemplo.com"
-              invalid={Boolean(err)}
+              aria-invalid={err ? true : undefined}
               aria-describedby={err ? "reset-email-error" : undefined}
             />
           </Field>

--- a/app/(auth)/update-password/page.tsx
+++ b/app/(auth)/update-password/page.tsx
@@ -158,7 +158,7 @@ function UpdatePasswordClient() {
               onChange={(e: any) => setP1(e.target.value)}
               placeholder="••••••••"
               required
-              invalid={Boolean(lengthError)}
+              aria-invalid={lengthError ? true : undefined}
               aria-describedby={lengthError ? "update-password-length" : undefined}
             />
           </Field>
@@ -179,7 +179,7 @@ function UpdatePasswordClient() {
               onChange={(e: any) => setP2(e.target.value)}
               placeholder="••••••••"
               required
-              invalid={Boolean(matchError)}
+              aria-invalid={matchError ? true : undefined}
               aria-describedby={matchError ? "update-password-match" : undefined}
             />
           </Field>

--- a/components/ExportPDFButton.tsx
+++ b/components/ExportPDFButton.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 
 type Props = {
   /** Referencia al nodo raíz a exportar */
-  targetRef?: React.RefObject<HTMLElement>;
+  targetRef?: React.RefObject<HTMLElement | null>;
   /** Alternativa: id del elemento si no usas ref */
   targetId?: string;
   /** Nombre de archivo (compatibilidad) */

--- a/components/patients/PatientAutocomplete.tsx
+++ b/components/patients/PatientAutocomplete.tsx
@@ -6,12 +6,24 @@ import { cn } from "@/lib/utils";
 
 type Item = { id: string; name: string; doc?: string };
 
+type Selection = {
+  id: string;
+  label: string;
+  name?: string;
+  doc?: string;
+};
+
 export default function PatientAutocomplete({
   onSelect,
   placeholder = "Buscar paciente",
-   orgId, scope, className,
+  orgId,
+  scope,
+  className,
 }: {
-  onSelect?: (p: Item | { id: string; label: string } | null) => void; orgId?: string; scope?: string; placeholder?: string;
+  onSelect?: (p: Selection | null) => void;
+  orgId?: string;
+  scope?: string;
+  placeholder?: string;
   className?: string;
 }) {
   const [q, setQ] = useState("");
@@ -38,7 +50,7 @@ export default function PatientAutocomplete({
         if (orgId) url.searchParams.set("org_id", orgId);
         if (scope) url.searchParams.set("scope", scope);
         const r = await fetch(url.toString(), { cache: "no-store" });
-const data = await r.json();
+        const data = await r.json();
         setItems((data?.items ?? []).slice(0, 8));
       } catch {
         setItems([]);
@@ -78,7 +90,7 @@ const data = await r.json();
                 key={it.id}
                 className="w-full text-left px-3 py-2 text-sm hover:bg-muted"
                 onClick={() => {
-                  onSelect?.(it);
+                  onSelect?.({ ...it, label: it.name });
                   setQ(it.name);
                   setOpen(false);
                 }}

--- a/components/saved-views/SavedViewsBar.tsx
+++ b/components/saved-views/SavedViewsBar.tsx
@@ -15,7 +15,7 @@ type SavedView = {
 
 type Props = {
   orgId: string;
-  scope: "bank_tx"; // extensible a otros módulos
+  scope: "bank_tx" | "reminders"; // extensible a otros módulos
 };
 
 export default function SavedViewsBar({ orgId, scope }: Props) {

--- a/components/shared/OrgInspector.tsx
+++ b/components/shared/OrgInspector.tsx
@@ -9,12 +9,16 @@ type Props = {
   children?: ReactNode;
   title?: string;
   description?: string;
+  ctaHref?: string;
+  ctaLabel?: string;
 };
 
 export default function OrgInspector({
   children,
   title = "Selecciona una organización activa para continuar.",
   description = "El contenido se habilita cuando eliges una organización en el switcher.",
+  ctaHref,
+  ctaLabel = "Ir a organizaciones",
 }: Props) {
   const [ready, setReady] = useState<boolean | null>(null);
 
@@ -43,7 +47,17 @@ export default function OrgInspector({
       <div className="rounded-lg border border-border p-4 bg-card">
         <div className="text-base font-semibold mb-1">{title}</div>
         <div className="text-sm text-muted-foreground mb-3">{description}</div>
-        <OrgSwitcherBadge />
+        <div className="flex flex-wrap gap-2">
+          <OrgSwitcherBadge />
+          {ctaHref ? (
+            <a
+              href={ctaHref}
+              className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm hover:bg-muted"
+            >
+              {ctaLabel}
+            </a>
+          ) : null}
+        </div>
       </div>
     );
   }

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -10,6 +10,8 @@ export type FieldProps = {
   description?: ReactNode;
   /** @deprecated Usa `description` en su lugar */
   hint?: ReactNode;
+  error?: ReactNode;
+  errorId?: string;
   children: ReactNode;
 };
 
@@ -20,9 +22,12 @@ export function Field({
   className,
   description,
   hint,
+  error,
+  errorId,
   children,
 }: FieldProps) {
   const descId = (description ?? hint) && htmlFor ? `${htmlFor}-desc` : undefined;
+  const resolvedErrorId = error ? errorId ?? (htmlFor ? `${htmlFor}-error` : undefined) : undefined;
 
   return (
     <div className={cn("grid gap-2", className)}>
@@ -36,6 +41,11 @@ export function Field({
       {description ?? hint ? (
         <span id={descId} className="text-xs text-muted-foreground">
           {description ?? hint}
+        </span>
+      ) : null}
+      {error ? (
+        <span id={resolvedErrorId} className="text-xs text-destructive">
+          {error}
         </span>
       ) : null}
     </div>

--- a/types/database-extended.d.ts
+++ b/types/database-extended.d.ts
@@ -269,6 +269,55 @@ export type Database = Base & {
         Update: Partial<{ id: string; org_id: string; name: string; content: any; active: boolean | null; updated_at: string | null; doctor_id?: string | null }>;
       };
 
+      agenda_appointments: {
+        Row: {
+          id: string;
+          org_id: string;
+          provider_id: string;
+          patient_id: string;
+          starts_at: string;
+          ends_at: string;
+          tz: string | null;
+          location: string | null;
+          notes: string | null;
+          status: "scheduled" | "completed" | "cancelled" | "no_show" | string | null;
+          created_by: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          provider_id: string;
+          patient_id: string;
+          starts_at: string;
+          ends_at: string;
+          tz?: string | null;
+          location?: string | null;
+          notes?: string | null;
+          status?: "scheduled" | "completed" | "cancelled" | "no_show" | string | null;
+          created_by?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: Partial<{
+          id: string;
+          org_id: string;
+          provider_id: string;
+          patient_id: string;
+          starts_at: string;
+          ends_at: string;
+          tz: string | null;
+          location: string | null;
+          notes: string | null;
+          status: "scheduled" | "completed" | "cancelled" | "no_show" | string | null;
+          created_by: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        }>;
+        Relationships: [];
+      };
+
       // Plantillas de laboratorios (mínimos)
       lab_templates: {
         Row: { id: string; org_id: string; name: string; body?: any; updated_at?: string | null; created_at?: string | null };


### PR DESCRIPTION
## Summary
- ensure the patient autocomplete emits label-friendly selections so agenda and module pages can store them without type errors
- extend OrgInspector with an optional CTA link, broaden saved views scope support, and harden export/print helpers for reminders and plans
- expose error messaging in the shared Field component and update auth flows to rely on aria-invalid rather than non-standard props
- register the agenda_appointments stub in the extended Supabase types used across the agenda API surface

## Testing
- `pnpm typecheck` *(fails: existing Supabase type definitions still missing broader coverage; see task context for details)*

------
https://chatgpt.com/codex/tasks/task_e_68e08cf2df7c832ab1dd72e54565ca7f