### PR TITLE
Add agenda table stubs to Supabase types

### DIFF
--- a/app/api/bank/rules/route.ts
+++ b/app/api/bank/rules/route.ts
@@ -2,7 +2,7 @@
 // Ruta: /api/bank/rules
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 type DB = Database;
 type Rule = DB["public"]["Tables"]["bank_rules"]["Row"];

--- a/app/api/bank/tx/bulk/route.ts
+++ b/app/api/bank/tx/bulk/route.ts
@@ -2,7 +2,7 @@
 // Ruta: /api/bank/tx/bulk
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 type DB = Database;
 type Tx = DB["public"]["Tables"]["bank_tx"]["Row"];

--- a/app/api/bank/tx/route.ts
+++ b/app/api/bank/tx/route.ts
@@ -2,7 +2,7 @@
 // Ruta: /api/bank/tx
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseServer } from "@/lib/supabase/server";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 type DB = Database;
 type Tx = DB["public"]["Tables"]["bank_tx"]["Row"];

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 
 /**

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -3,7 +3,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createBrowserClient } from "@supabase/ssr";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 const NOT_CONFIGURED_MSG = "Supabase no está configurado";
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -2,7 +2,7 @@
 import { cookies as nextCookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import { createClient as createSupabaseAdmin, type SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 const NOT_CONFIGURED_MSG = "Supabase no está configurado";
 

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,6 +1,6 @@
 // /workspaces/sanoa-lab/lib/supabase/service.ts
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database-extended";
 
 const NOT_CONFIGURED_MSG = "Supabase (service) no está configurado";
 

--- a/types/database-extended.d.ts
+++ b/types/database-extended.d.ts
@@ -282,6 +282,160 @@ export type Database = Base & {
         Insert: { id?: string; org_id: string; assignment_id?: string | null; type?: string | null; created_at?: string | null; payload?: any | null };
         Update: Partial<{ id: string; org_id: string; assignment_id: string | null; type: string | null; created_at: string | null; payload: any | null }>;
       };
+
+      /**
+       * =======================
+       * AGENDAS (disponibilidad, overrides, citas, puntajes)
+       * =======================
+       */
+
+      agenda_availability: {
+        Row: {
+          id: string;
+          org_id: string;
+          provider_id: string;
+          weekday: number;
+          start_time: string;
+          end_time: string;
+          slot_minutes: number | null;
+          tz: string;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          provider_id: string;
+          weekday: number;
+          start_time: string;
+          end_time: string;
+          slot_minutes?: number | null;
+          tz: string;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: Partial<{
+          id: string;
+          org_id: string;
+          provider_id: string;
+          weekday: number;
+          start_time: string;
+          end_time: string;
+          slot_minutes: number | null;
+          tz: string;
+          created_at: string | null;
+          updated_at: string | null;
+        }>;
+        Relationships: [];
+      };
+
+      agenda_slots_overrides: {
+        Row: {
+          id: string;
+          org_id: string;
+          provider_id: string;
+          date: string;
+          kind: string;
+          start_time: string;
+          end_time: string;
+          notes: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          provider_id: string;
+          date: string;
+          kind: string;
+          start_time: string;
+          end_time: string;
+          notes?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: Partial<{
+          id: string;
+          org_id: string;
+          provider_id: string;
+          date: string;
+          kind: string;
+          start_time: string;
+          end_time: string;
+          notes: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        }>;
+        Relationships: [];
+      };
+
+      agenda_appointments: {
+        Row: {
+          id: string;
+          org_id: string;
+          provider_id: string;
+          patient_id: string | null;
+          starts_at: string;
+          ends_at: string;
+          status: string;
+          kind: string | null;
+          notes: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          provider_id: string;
+          patient_id?: string | null;
+          starts_at: string;
+          ends_at: string;
+          status?: string;
+          kind?: string | null;
+          notes?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: Partial<{
+          id: string;
+          org_id: string;
+          provider_id: string;
+          patient_id: string | null;
+          starts_at: string;
+          ends_at: string;
+          status: string;
+          kind: string | null;
+          notes: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        }>;
+        Relationships: [];
+      };
+
+      agenda_ns_scores: {
+        Row: {
+          id: string;
+          org_id: string;
+          patient_id: string;
+          score: number;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: string;
+          patient_id: string;
+          score: number;
+          updated_at?: string | null;
+        };
+        Update: Partial<{
+          id: string;
+          org_id: string;
+          patient_id: string;
+          score: number;
+          updated_at: string | null;
+        }>;
+        Relationships: [];
+      };
     };
 
     Functions: Public["Functions"] & {


### PR DESCRIPTION
## Summary
- extend the Supabase type augmentation with agenda availability, overrides, appointments, and no-show score tables so agenda endpoints compile
- point shared Supabase helpers at the extended type bundle so the new table stubs are applied consistently

## Testing
- `pnpm typecheck` *(fails: existing type errors across reminders/reports modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e08d0f84a0832ab9c20d64d67c405b